### PR TITLE
docs: fix wrong link in Getting Started to askui User Portal signup

### DIFF
--- a/docs/docs/general/02-Getting Started/getting-started.md
+++ b/docs/docs/general/02-Getting Started/getting-started.md
@@ -41,6 +41,6 @@ If you don't like Jest, feel free to use another test framework, e.g., [Jasmine]
 
 Currently, you can use our lib without any configuration. But in the future, as we need to prevent misuse of our api, we may need you to create some credentials through our [askui user portal](https://app.askui.com/) (still, totally free) and [configure our library to use these credentials](../../api/06-Configuration/askui-ui-control-client.md#credentials) for authenticating and authorising with our api.
 
-Please see [our documention on how to signup and create the credentials](../askui%20User%20Portal/signup.md).
+Please see [our documention on how to signup and create the credentials](../08-askui%20User%20Portal/signup.md).
 
 Now, we are ready to write our first test.

--- a/docs/versioned_docs/version-0.2.7/general/02-Getting Started/getting-started.md
+++ b/docs/versioned_docs/version-0.2.7/general/02-Getting Started/getting-started.md
@@ -40,4 +40,6 @@ If you don't like Jest, feel free to use another test framework, e.g., [Jasmine]
 
 Currently, you can use our lib without any configuration. But in the future, as we need to prevent misuse of our api, we may need you to create some credentials through our [askui user portal](https://app.askui.com/) (still, totally free) and [configure our library to use these credentials](../../api/06-Configuration/askui-ui-control-client.md#credentials) for authenticating and authorising with our api.
 
+Please see [our documention on how to signup and create the credentials](../08-askui%20User%20Portal/signup.md).
+
 Now, we are ready to write our first test.


### PR DESCRIPTION
I did not realise that _npm run start_ compiles even if there are wrong links.

But _npm run build_ fails with that.