### PR TITLE
docs: fixed wrong file name in writing-your-first-test.md

### DIFF
--- a/docs/docs/general/02-Getting Started/writing-your-first-test.md
+++ b/docs/docs/general/02-Getting Started/writing-your-first-test.md
@@ -25,7 +25,7 @@ This is going to create
 We need you to create some credentials through our [askui user portal](https://app.askui.com/) (usage is free!).
 Please see <a href="../askui%20User%20Portal/signup" target="_blank">our documentation on how to signup and create the credentials</a>.
 
-Then, go to your `jest.config.ts` and add the configuration for your `workspace id` and your `access token` to the _UiControlClient_.
+Then, go to your `helper/jest.setup.ts` and add the configuration for your `workspace id` and your `access token` to the _UiControlClient_.
 
 ```typescript
  aui = await UiControlClient.build({

--- a/docs/versioned_docs/version-0.2.7/general/02-Getting Started/writing-your-first-test.md
+++ b/docs/versioned_docs/version-0.2.7/general/02-Getting Started/writing-your-first-test.md
@@ -25,7 +25,7 @@ This is going to create
 We need you to create some credentials through our [askui user portal](https://app.askui.com/) (usage is free!).
 Please see <a href="../askui%20User%20Portal/signup" target="_blank">our documentation on how to signup and create the credentials</a>.
 
-Then, go to your `jest.config.ts` and add the configuration for your `workspace id` and your `access token` to the _UiControlClient_.
+Then, go to your `helper/jest.setup.ts` and add the configuration for your `workspace id` and your `access token` to the _UiControlClient_.
 
 ```typescript
  aui = await UiControlClient.build({

--- a/docs/versioned_docs/version-0.3.1/general/02-Getting Started/writing-your-first-test.md
+++ b/docs/versioned_docs/version-0.3.1/general/02-Getting Started/writing-your-first-test.md
@@ -25,7 +25,7 @@ This is going to create
 We need you to create some credentials through our [askui user portal](https://app.askui.com/) (usage is free!).
 Please see <a href="../askui%20User%20Portal/signup" target="_blank">our documentation on how to signup and create the credentials</a>.
 
-Then, go to your `jest.config.ts` and add the configuration for your `workspace id` and your `access token` to the _UiControlClient_.
+Then, go to your `helper/jest.setup.ts` and add the configuration for your `workspace id` and your `access token` to the _UiControlClient_.
 
 ```typescript
  aui = await UiControlClient.build({

--- a/docs/versioned_docs/version-0.3.2/general/02-Getting Started/writing-your-first-test.md
+++ b/docs/versioned_docs/version-0.3.2/general/02-Getting Started/writing-your-first-test.md
@@ -25,7 +25,7 @@ This is going to create
 We need you to create some credentials through our [askui user portal](https://app.askui.com/) (usage is free!).
 Please see <a href="../askui%20User%20Portal/signup" target="_blank">our documentation on how to signup and create the credentials</a>.
 
-Then, go to your `jest.config.ts` and add the configuration for your `workspace id` and your `access token` to the _UiControlClient_.
+Then, go to your `helper/jest.setup.ts` and add the configuration for your `workspace id` and your `access token` to the _UiControlClient_.
 
 ```typescript
  aui = await UiControlClient.build({


### PR DESCRIPTION
While doing a Developer Experience Audit with Haram we noticed that the mentioned file under helper/writing-your-first-test.md -> Configuration ist wrong!

It must be **helper/jest.setup.ts** and not **jest.config.ts**. Really nasty mistake which completely throws of new users!