### PR TITLE
docs: upgrade npx askui init to take workspaceId and accessToken with…

### DIFF
--- a/packages/askui-nodejs/.eslintrc.js
+++ b/packages/askui-nodejs/.eslintrc.js
@@ -35,5 +35,19 @@ module.exports = {
         '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       },
     },
+    {
+      files: ['example_projects_templates/**/*.ts'],
+      extends: [
+        'plugin:@typescript-eslint/recommended',
+        'airbnb-typescript/base',
+      ],
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        createDefaultProgram: true,
+      },
+      rules: {
+        'import/no-extraneous-dependencies': 'off',
+      },
+    },
   ],
 };

--- a/packages/askui-nodejs/example_projects_templates/typescript_jest/test/helper/jest.setup.ts
+++ b/packages/askui-nodejs/example_projects_templates/typescript_jest/test/helper/jest.setup.ts
@@ -1,4 +1,4 @@
-import { UiControlClient, UiController } from 'askui';
+import { UiControlClient, UiController } from 'askui'; // eslint-disable-line import/no-extraneous-dependencies
 
 // Server for controlling the operating system
 let uiController: UiController;
@@ -20,7 +20,12 @@ beforeAll(async () => {
 
   await uiController.start();
 
-  aui = await UiControlClient.build();
+  aui = await UiControlClient.build({
+    credentials: {
+      workspaceId: '<your workspace id>',
+      token: '<your access token>',
+    },
+  });
 
   await aui.connect();
 });

--- a/packages/askui-nodejs/example_projects_templates/typescript_jest/test/helper/jest.setup.ts
+++ b/packages/askui-nodejs/example_projects_templates/typescript_jest/test/helper/jest.setup.ts
@@ -1,4 +1,4 @@
-import { UiControlClient, UiController } from 'askui'; // eslint-disable-line import/no-extraneous-dependencies
+import { UiControlClient, UiController } from 'askui';
 
 // Server for controlling the operating system
 let uiController: UiController;

--- a/packages/askui-nodejs/example_projects_templates/typescript_jest/test/my-first-askui-test-suite.test.ts
+++ b/packages/askui-nodejs/example_projects_templates/typescript_jest/test/my-first-askui-test-suite.test.ts
@@ -9,6 +9,7 @@ describe('jest with askui', () => {
     await aui.moveMouse(0, 0).exec();
     await aui
       .click()
+      .text()
       .withText('Click on this text right here!')
       .exec();
   });

--- a/packages/askui-nodejs/example_projects_templates/typescript_jest/test/my-first-askui-test-suite.test.ts
+++ b/packages/askui-nodejs/example_projects_templates/typescript_jest/test/my-first-askui-test-suite.test.ts
@@ -2,9 +2,14 @@ import { aui } from './helper/jest.setup';
 
 describe('jest with askui', () => {
   it('should click on text', async () => {
+    // Run this to see what askui annotates
+    await aui.annotateInteractively();
+
+    // TODO Validate this works
+    await aui.moveMouse(0, 0).exec();
     await aui
       .click()
-      .text()
+      .withText('Click on this text right here!')
       .exec();
   });
 });

--- a/packages/askui-nodejs/example_projects_templates/typescript_jest/test/my-first-askui-test-suite.test.ts
+++ b/packages/askui-nodejs/example_projects_templates/typescript_jest/test/my-first-askui-test-suite.test.ts
@@ -5,7 +5,6 @@ describe('jest with askui', () => {
     // Run this to see what askui annotates
     await aui.annotateInteractively();
 
-    // TODO Validate this works
     await aui.moveMouse(0, 0).exec();
     await aui
       .click()

--- a/packages/askui-nodejs/src/lib/copy-example-project.ts
+++ b/packages/askui-nodejs/src/lib/copy-example-project.ts
@@ -16,9 +16,10 @@ async function replaceStringInFile(filePath: string, replace: string, replacemen
     const result = data.replace(replace, replacement);
     await fs.writeFile(filePath, result, 'utf8');
   } catch (error: unknown) {
-    logger.error(`Could not replace '${replace}' with ${replacement} in file ${path}`);
-    if (error instanceof Error) {
-      logger.error(error.message);
+    logger.error(`Could not replace '${replace}' with '${replacement}' in file '${path}'`);
+
+    if ((<Error> error).message) {
+      logger.error((<Error> error).message);
     }
   }
 }
@@ -43,8 +44,8 @@ export function init(argv: string[]): Command {
   program
     .command('init')
     .description('creates a typescript example project')
-    .option('-w, --workspace-id <value>', 'the workspace id')
-    .option('-a, --access-token <value>', 'the access token')
+    .option('-w, --workspace-id <value>', 'a workspace id')
+    .option('-a, --access-token <value>', 'an access token for the workspace with the id')
     .usage('[-w workspace_id] [-a access_token]')
     .action(async (opts: OptionValues) => {
       await copyExampleProject(opts);

--- a/packages/askui-nodejs/src/lib/copy-example-project.ts
+++ b/packages/askui-nodejs/src/lib/copy-example-project.ts
@@ -17,10 +17,7 @@ async function replaceStringInFile(filePath: string, replace: string, replacemen
     await fs.writeFile(filePath, result, 'utf8');
   } catch (error: unknown) {
     logger.error(`Could not replace '${replace}' with '${replacement}' in file '${path}'`);
-
-    if ((<Error> error).message) {
-      logger.error((<Error> error).message);
-    }
+    logger.error((error as Error).message);
   }
 }
 

--- a/packages/askui-nodejs/src/lib/copy-example-project.ts
+++ b/packages/askui-nodejs/src/lib/copy-example-project.ts
@@ -1,24 +1,53 @@
-import { Command } from 'commander';
+import { Command, OptionValues } from 'commander';
 import path from 'path';
 import fs from 'fs-extra';
 import { getPathToNodeModulesRoot } from '../utils/path';
+import { logger } from './logger';
 
 const createProgram = () => {
   const program = new Command('askui');
   program.usage('<command> [options]');
   return program;
 };
-function copyExampleProject() {
+
+async function replaceStringInFile(filePath: string, replace: string, replacement: string) {
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    const result = data.replace(replace, replacement);
+    await fs.writeFile(filePath, result, 'utf8');
+  } catch (error: unknown) {
+    logger.error(`Could not replace '${replace}' with ${replacement} in file ${path}`);
+    if (error instanceof Error) {
+      logger.error(error.message);
+    }
+  }
+}
+
+async function copyExampleProject(options: OptionValues) {
   const exampleProjectPath = path.join('example_projects_templates', 'typescript_jest');
   fs.copySync(path.join(getPathToNodeModulesRoot(), exampleProjectPath), '.');
+
+  if (options['workspaceId']) {
+    await replaceStringInFile('./test/helper/jest.setup.ts', '<your workspace id>', options['workspaceId']);
+  }
+
+  if (options['accessToken']) {
+    await replaceStringInFile('./test/helper/jest.setup.ts', '<your access token>', options['accessToken']);
+  }
 }
 
 export function init(argv: string[]): Command {
   const args = argv || process.argv;
   const program = createProgram();
+
   program
     .command('init')
     .description('creates a typescript example project')
-    .action(() => { copyExampleProject(); });
+    .option('-w, --workspace-id <value>', 'the workspace id')
+    .option('-a, --access-token <value>', 'the access token')
+    .usage('[-w workspace_id] [-a access_token]')
+    .action(async (opts: OptionValues) => {
+      await copyExampleProject(opts);
+    });
   return program.parse(args);
 }


### PR DESCRIPTION
Upgrade the command `npx askui init` to accept the `workspaceId` and the `accessToken` as options:

You can now do this:
```
npx askui init -w 123123123 -a 99999999 
npx askui init --workspace-id 123123123 --access-token 99999999
```

It then replaces the strings `<your workspace id>` `<your access token>` in the file `test/helper/jest.setup.ts`

We can provide this command in our user portal and setup becomes much easier!

---------------------------------------------------------------------------------------------------------------------
Upgrade the test case of the example project to do the following:

1. annotateInteractively() -> So the user immediately sees something and can explore the annotation
2. move the mouse to the upper left corner -> User experiences mouse movement
3. the mouse moves back and clicks on the text in the test file

I hope this accomplishes two things:

1. The user gets feedback if the tool is running via annotation and later with watchable movement
2. The mouse movement should give an immediate 'aha'-effect because it is real movement and no jumping around

---------------------------------------------------------------------------------------------------------------------