### PR TITLE
docs: fix missing function in Table of Contents

### DIFF
--- a/docs/docs/api/01-API/table-of-contents.md
+++ b/docs/docs/api/01-API/table-of-contents.md
@@ -202,6 +202,8 @@ displayed_sidebar: apiSidebar
 
 -  [withText](../filters/withtext)
 
+-  [withTextRegex](../filters/withtextregex)
+
 -  [wizard](../filters/wizard)
 
 -  [wizardItem](../filters/wizarditem)

--- a/docs/versioned_docs/version-0.2.3/api/01-API/table-of-contents.md
+++ b/docs/versioned_docs/version-0.2.3/api/01-API/table-of-contents.md
@@ -203,6 +203,8 @@ custom_edit_url: null
 
 -  [withText](../filters/withtext)
 
+-  [withTextRegex](../filters/withtextregex)
+
 -  [wizard](../filters/wizard)
 
 -  [wizardItem](../filters/wizarditem)

--- a/docs/versioned_docs/version-0.2.4/api/01-API/table-of-contents.md
+++ b/docs/versioned_docs/version-0.2.4/api/01-API/table-of-contents.md
@@ -203,6 +203,8 @@ custom_edit_url: null
 
 -  [withText](../filters/withtext)
 
+-  [withTextRegex](../filters/withtextregex)
+
 -  [wizard](../filters/wizard)
 
 -  [wizardItem](../filters/wizarditem)

--- a/docs/versioned_docs/version-0.2.5/api/01-API/table-of-contents.md
+++ b/docs/versioned_docs/version-0.2.5/api/01-API/table-of-contents.md
@@ -203,6 +203,8 @@ custom_edit_url: null
 
 -  [withText](../filters/withtext)
 
+-  [withTextRegex](../filters/withtextregex)
+
 -  [wizard](../filters/wizard)
 
 -  [wizardItem](../filters/wizarditem)

--- a/docs/versioned_docs/version-0.2.6/api/01-API/table-of-contents.md
+++ b/docs/versioned_docs/version-0.2.6/api/01-API/table-of-contents.md
@@ -203,6 +203,8 @@ custom_edit_url: null
 
 -  [withText](../filters/withtext)
 
+-  [withTextRegex](../filters/withtextregex)
+
 -  [wizard](../filters/wizard)
 
 -  [wizardItem](../filters/wizarditem)

--- a/docs/versioned_docs/version-0.2.7/api/01-API/table-of-contents.md
+++ b/docs/versioned_docs/version-0.2.7/api/01-API/table-of-contents.md
@@ -202,6 +202,8 @@ displayed_sidebar: apiSidebar
 
 -  [withText](../filters/withtext)
 
+-  [withTextRegex](../filters/withtextregex)
+
 -  [wizard](../filters/wizard)
 
 -  [wizardItem](../filters/wizarditem)

--- a/docs/versioned_docs/version-0.3.1/api/01-API/table-of-contents.md
+++ b/docs/versioned_docs/version-0.3.1/api/01-API/table-of-contents.md
@@ -202,6 +202,8 @@ displayed_sidebar: apiSidebar
 
 -  [withText](../filters/withtext)
 
+-  [withTextRegex](../filters/withtextregex)
+
 -  [wizard](../filters/wizard)
 
 -  [wizardItem](../filters/wizarditem)

--- a/docs/versioned_docs/version-0.3.2/api/01-API/table-of-contents.md
+++ b/docs/versioned_docs/version-0.3.2/api/01-API/table-of-contents.md
@@ -202,6 +202,8 @@ displayed_sidebar: apiSidebar
 
 -  [withText](../filters/withtext)
 
+-  [withTextRegex](../filters/withtextregex)
+
 -  [wizard](../filters/wizard)
 
 -  [wizardItem](../filters/wizarditem)

--- a/docs/versioned_docs/version-0.4.0/api/01-API/table-of-contents.md
+++ b/docs/versioned_docs/version-0.4.0/api/01-API/table-of-contents.md
@@ -202,6 +202,8 @@ displayed_sidebar: apiSidebar
 
 -  [withText](../filters/withtext)
 
+-  [withTextRegex](../filters/withtextregex)
+
 -  [wizard](../filters/wizard)
 
 -  [wizardItem](../filters/wizarditem)

--- a/docs/versioned_docs/version-0.5.0/api/01-API/table-of-contents.md
+++ b/docs/versioned_docs/version-0.5.0/api/01-API/table-of-contents.md
@@ -202,6 +202,8 @@ displayed_sidebar: apiSidebar
 
 -  [withText](../filters/withtext)
 
+-  [withTextRegex](../filters/withtextregex)
+
 -  [wizard](../filters/wizard)
 
 -  [wizardItem](../filters/wizarditem)


### PR DESCRIPTION
added 'withTextRegex' to Table of Contents of version>0.2.2