### PR TITLE
docs: extend docs for type(), typeIn(), pressKey*(); Tutorial title renaming

### DIFF
--- a/docs/docs/api/02-Commands/presskey.md
+++ b/docs/docs/api/02-Commands/presskey.md
@@ -3,6 +3,10 @@ displayed_sidebar: apiSidebar
 ---
 # pressKey
 
-Press one keys like `DEL`
+Press one key like `DEL`
+
+**Operating system specific mappings:**
+1. Windows: `command`-key maps to `windows`-key
+---
 
    * @param {PC_AND_MODIFIER_KEY} key - A key

--- a/docs/docs/api/02-Commands/pressthreekeys.md
+++ b/docs/docs/api/02-Commands/pressthreekeys.md
@@ -5,6 +5,10 @@ displayed_sidebar: apiSidebar
 
 Press three keys like `CTRL+ALT+DEL`
 
+**Operating system specific mappings:**
+1. Windows: `command`-key maps to `windows`-key
+---
+
    * @param {MODIFIER_KEY} first_key - A modifier key
    * @param {MODIFIER_KEY} second_key - A modifier key
    * @param {PC_KEY} third_key - A key

--- a/docs/docs/api/02-Commands/presstwokeys.md
+++ b/docs/docs/api/02-Commands/presstwokeys.md
@@ -5,5 +5,9 @@ displayed_sidebar: apiSidebar
 
 Press two keys like `ALT+F4`
 
+**Operating system specific mappings:**
+1. Windows: `command`-key maps to `windows`-key
+---
+
    * @param {MODIFIER_KEY} first_key - A modifier key
    * @param {PC_KEY} second_key - A key

--- a/docs/docs/api/02-Commands/type.md
+++ b/docs/docs/api/02-Commands/type.md
@@ -6,6 +6,8 @@ displayed_sidebar: apiSidebar
 Types a text at the current position.
 If you need to focus the element first, use `typeIn()`.
 
+**Note:** In the current version it copies the text and pastes it.
+
 By default, the `text` is included in the logs and sent over to the askui Inference server to
 predict in which context the typing has to occur. You can exclude the `text` from the logs
 and the request to the askui Inference server setting `options.isSecret` to `true`.

--- a/docs/docs/api/02-Commands/typein.md
+++ b/docs/docs/api/02-Commands/typein.md
@@ -5,6 +5,8 @@ displayed_sidebar: apiSidebar
 
 Puts the focus on the filtered element by click/tap and types in the text.
 
+**Note:** In the current version it copies the text and pastes it.
+
 By default, the `text` is included in the logs and sent over to the askui Inference server to
 predict in which context the typing has to occur. You can exclude the `text` from the logs
 and the request to the askui Inference server setting `options.isSecret` to `true`.

--- a/docs/docs/general/06-Tutorials/android-search-in-browser.md
+++ b/docs/docs/general/06-Tutorials/android-search-in-browser.md
@@ -2,7 +2,7 @@
 sidebar_position: 4
 ---
 
-# Automate Web Search on Android Devices with askui
+# Web Search on Android
 
 In this tutorial, we will automate web searching on Android devices. This tutorial assumes that you have already set up your Android Development Environment. If you haven't set it up yet, you can check out our [Setup Android tutorial](setup-android.md).
 

--- a/docs/docs/general/06-Tutorials/custom-element.md
+++ b/docs/docs/general/06-Tutorials/custom-element.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Custom Elements in askui
+# Custom Elements
 :::caution
 
 **Important**: This increases the runtime quite a bit. So use it only if absolutely necessary.

--- a/docs/docs/general/06-Tutorials/google-cat-search.md
+++ b/docs/docs/general/06-Tutorials/google-cat-search.md
@@ -2,7 +2,7 @@
 sidebar_position: 5
 ---
 
-# Google Cat Search Tutorial
+# Google Cat Image Search
 
 The following tutorial shows you how to search for cat images on Google Image Search with askui.
 

--- a/docs/docs/general/06-Tutorials/setup-android.md
+++ b/docs/docs/general/06-Tutorials/setup-android.md
@@ -2,7 +2,7 @@
 sidebar_position: 3
 ---
 
-# Setting up Android Devices for Testing Mobile Apps
+# Setting up Android Devices
 
 In this tutorial, we will walk you through how to set up an Android device for automating mobile apps running on Android devices. Depending on the environment, i.e. whether it is a real Android device or an emulator, the procedure might slightly differ. But the overall process of the setup will be more or less the same. 
 

--- a/docs/docs/general/06-Tutorials/shop-demo.md
+++ b/docs/docs/general/06-Tutorials/shop-demo.md
@@ -2,7 +2,7 @@
 sidebar_position: 6
 ---
 
-# Online Shop Tutorial
+# Online Shop Login
 
 The following tutorial shows how to automate the login process of a simple demo online shop.
 

--- a/docs/docs/general/06-Tutorials/spotify-tutorial.md
+++ b/docs/docs/general/06-Tutorials/spotify-tutorial.md
@@ -2,7 +2,7 @@
 sidebar_position: 7
 ---
 
-# Desktop App Automation Tutorial
+# Like on Spotify Desktop App
 
 The following tutorial shows how to automate a desktop application. As an example we will automatically to like songs in the Spotify desktop application.
 

--- a/docs/docs/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/docs/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -2,7 +2,7 @@
 sidebar_position: 8
 ---
 
-# Zip Images and Upload them to Google Drive on Windows OS Tutorial
+# Zip Images and Upload to Google Drive on Windows
 
 This tutorial will show you how to zip files on your file system and then upload them to Google Drive with askui.
 

--- a/docs/versioned_docs/version-0.7.0/api/02-Commands/presskey.md
+++ b/docs/versioned_docs/version-0.7.0/api/02-Commands/presskey.md
@@ -5,4 +5,8 @@ displayed_sidebar: apiSidebar
 
 Press one keys like `DEL`
 
+**Operating system specific mappings:**
+1. Windows: `command`-key maps to `windows`-key
+---
+
    * @param {PC_AND_MODIFIER_KEY} key - A key

--- a/docs/versioned_docs/version-0.7.0/api/02-Commands/pressthreekeys.md
+++ b/docs/versioned_docs/version-0.7.0/api/02-Commands/pressthreekeys.md
@@ -5,6 +5,10 @@ displayed_sidebar: apiSidebar
 
 Press three keys like `CTRL+ALT+DEL`
 
+**Operating system specific mappings:**
+1. Windows: `command`-key maps to `windows`-key
+---
+
    * @param {MODIFIER_KEY} first_key - A modifier key
    * @param {MODIFIER_KEY} second_key - A modifier key
    * @param {PC_KEY} third_key - A key

--- a/docs/versioned_docs/version-0.7.0/api/02-Commands/presstwokeys.md
+++ b/docs/versioned_docs/version-0.7.0/api/02-Commands/presstwokeys.md
@@ -5,5 +5,9 @@ displayed_sidebar: apiSidebar
 
 Press two keys like `ALT+F4`
 
+**Operating system specific mappings:**
+1. Windows: `command`-key maps to `windows`-key
+---
+
    * @param {MODIFIER_KEY} first_key - A modifier key
    * @param {PC_KEY} second_key - A key

--- a/docs/versioned_docs/version-0.7.0/api/02-Commands/type.md
+++ b/docs/versioned_docs/version-0.7.0/api/02-Commands/type.md
@@ -6,6 +6,8 @@ displayed_sidebar: apiSidebar
 Types a text at the current position.
 If you need to focus the element first, use `typeIn()`.
 
+**Note:** In the current version it copies the text and pastes it.
+
 By default, the `text` is included in the logs and sent over to the askui Inference server to
 predict in which context the typing has to occur. You can exclude the `text` from the logs
 and the request to the askui Inference server setting `options.isSecret` to `true`.

--- a/docs/versioned_docs/version-0.7.0/api/02-Commands/typein.md
+++ b/docs/versioned_docs/version-0.7.0/api/02-Commands/typein.md
@@ -5,6 +5,8 @@ displayed_sidebar: apiSidebar
 
 Puts the focus on the filtered element by click/tap and types in the text.
 
+**Note:** In the current version it copies the text and pastes it.
+
 By default, the `text` is included in the logs and sent over to the askui Inference server to
 predict in which context the typing has to occur. You can exclude the `text` from the logs
 and the request to the askui Inference server setting `options.isSecret` to `true`.

--- a/docs/versioned_docs/version-0.7.1/api/02-Commands/presskey.md
+++ b/docs/versioned_docs/version-0.7.1/api/02-Commands/presskey.md
@@ -5,4 +5,8 @@ displayed_sidebar: apiSidebar
 
 Press one keys like `DEL`
 
+**Operating system specific mappings:**
+1. Windows: `command`-key maps to `windows`-key
+---
+
    * @param {PC_AND_MODIFIER_KEY} key - A key

--- a/docs/versioned_docs/version-0.7.1/api/02-Commands/pressthreekeys.md
+++ b/docs/versioned_docs/version-0.7.1/api/02-Commands/pressthreekeys.md
@@ -5,6 +5,10 @@ displayed_sidebar: apiSidebar
 
 Press three keys like `CTRL+ALT+DEL`
 
+**Operating system specific mappings:**
+1. Windows: `command`-key maps to `windows`-key
+---
+
    * @param {MODIFIER_KEY} first_key - A modifier key
    * @param {MODIFIER_KEY} second_key - A modifier key
    * @param {PC_KEY} third_key - A key

--- a/docs/versioned_docs/version-0.7.1/api/02-Commands/presstwokeys.md
+++ b/docs/versioned_docs/version-0.7.1/api/02-Commands/presstwokeys.md
@@ -5,5 +5,9 @@ displayed_sidebar: apiSidebar
 
 Press two keys like `ALT+F4`
 
+**Operating system specific mappings:**
+1. Windows: `command`-key maps to `windows`-key
+---
+
    * @param {MODIFIER_KEY} first_key - A modifier key
    * @param {PC_KEY} second_key - A key

--- a/docs/versioned_docs/version-0.7.1/api/02-Commands/type.md
+++ b/docs/versioned_docs/version-0.7.1/api/02-Commands/type.md
@@ -6,6 +6,8 @@ displayed_sidebar: apiSidebar
 Types a text at the current position.
 If you need to focus the element first, use `typeIn()`.
 
+**Note:** In the current version it copies the text and pastes it.
+
 By default, the `text` is included in the logs and sent over to the askui Inference server to
 predict in which context the typing has to occur. You can exclude the `text` from the logs
 and the request to the askui Inference server setting `options.isSecret` to `true`.

--- a/docs/versioned_docs/version-0.7.1/api/02-Commands/typein.md
+++ b/docs/versioned_docs/version-0.7.1/api/02-Commands/typein.md
@@ -5,6 +5,8 @@ displayed_sidebar: apiSidebar
 
 Puts the focus on the filtered element by click/tap and types in the text.
 
+**Note:** In the current version it copies the text and pastes it.
+
 By default, the `text` is included in the logs and sent over to the askui Inference server to
 predict in which context the typing has to occur. You can exclude the `text` from the logs
 and the request to the askui Inference server setting `options.isSecret` to `true`.

--- a/docs/versioned_docs/version-0.7.2/api/02-Commands/presskey.md
+++ b/docs/versioned_docs/version-0.7.2/api/02-Commands/presskey.md
@@ -3,6 +3,10 @@ displayed_sidebar: apiSidebar
 ---
 # pressKey
 
-Press one keys like `DEL`
+Press one key like `DEL`
+
+**Operating system specific mappings:**
+1. Windows: `command`-key maps to `windows`-key
+---
 
    * @param {PC_AND_MODIFIER_KEY} key - A key

--- a/docs/versioned_docs/version-0.7.2/api/02-Commands/pressthreekeys.md
+++ b/docs/versioned_docs/version-0.7.2/api/02-Commands/pressthreekeys.md
@@ -5,6 +5,10 @@ displayed_sidebar: apiSidebar
 
 Press three keys like `CTRL+ALT+DEL`
 
+**Operating system specific mappings:**
+1. Windows: `command`-key maps to `windows`-key
+---
+
    * @param {MODIFIER_KEY} first_key - A modifier key
    * @param {MODIFIER_KEY} second_key - A modifier key
    * @param {PC_KEY} third_key - A key

--- a/docs/versioned_docs/version-0.7.2/api/02-Commands/presstwokeys.md
+++ b/docs/versioned_docs/version-0.7.2/api/02-Commands/presstwokeys.md
@@ -5,5 +5,9 @@ displayed_sidebar: apiSidebar
 
 Press two keys like `ALT+F4`
 
+**Operating system specific mappings:**
+1. Windows: `command`-key maps to `windows`-key
+---
+
    * @param {MODIFIER_KEY} first_key - A modifier key
    * @param {PC_KEY} second_key - A key

--- a/docs/versioned_docs/version-0.7.2/api/02-Commands/type.md
+++ b/docs/versioned_docs/version-0.7.2/api/02-Commands/type.md
@@ -6,6 +6,8 @@ displayed_sidebar: apiSidebar
 Types a text at the current position.
 If you need to focus the element first, use `typeIn()`.
 
+**Note:** In the current version it copies the text and pastes it.
+
 By default, the `text` is included in the logs and sent over to the askui Inference server to
 predict in which context the typing has to occur. You can exclude the `text` from the logs
 and the request to the askui Inference server setting `options.isSecret` to `true`.

--- a/docs/versioned_docs/version-0.7.2/api/02-Commands/typein.md
+++ b/docs/versioned_docs/version-0.7.2/api/02-Commands/typein.md
@@ -5,6 +5,8 @@ displayed_sidebar: apiSidebar
 
 Puts the focus on the filtered element by click/tap and types in the text.
 
+**Note:** In the current version it copies the text and pastes it.
+
 By default, the `text` is included in the logs and sent over to the askui Inference server to
 predict in which context the typing has to occur. You can exclude the `text` from the logs
 and the request to the askui Inference server setting `options.isSecret` to `true`.


### PR DESCRIPTION
* pressKey*(): Added hint that `command` on Windows OS is the `windows`-key
* type(), typeIn(): Add note that in it copy+pastes instead of typing