### PR TITLE
docs: Add link before YouTube videos to retrigger the CookieConsent scripts

### DIFF
--- a/docs/docs/general/06-Tutorials/custom-element.md
+++ b/docs/docs/general/06-Tutorials/custom-element.md
@@ -22,6 +22,9 @@ Here we will demonstrate how to use a custom element to explore Google Street Vi
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube.com/watch?v=M00BCweamDc&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Requirements

--- a/docs/docs/general/06-Tutorials/custom-element.md
+++ b/docs/docs/general/06-Tutorials/custom-element.md
@@ -23,7 +23,7 @@ Here we will demonstrate how to use a custom element to explore Google Street Vi
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube.com/watch?v=M00BCweamDc&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/docs/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/docs/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -10,9 +10,9 @@ This tutorial will show you how to zip files on your file system and then upload
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
-<iframe onload="rerunCookieConsentScripts(0);" width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
 ## Setup

--- a/docs/docs/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/docs/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -9,8 +9,11 @@ This tutorial will show you how to zip files on your file system and then upload
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
+<iframe onload="rerunCookieConsentScripts(0);" width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Setup
 

--- a/docs/static/scripts/reinitCookieConsent.js
+++ b/docs/static/scripts/reinitCookieConsent.js
@@ -8,10 +8,3 @@ function rerunCookieConsentScripts(retries) {
         }
     }
 }
-
-window.addEventListener('CookiebotOnConsentReady', function () {
-    const iframes = document.getElementsByTagName("iframe");
-    if (iframes.length > 0) {
-        rerunCookieConsentScripts(0);  
-    }
-})

--- a/docs/static/scripts/reinitCookieConsent.js
+++ b/docs/static/scripts/reinitCookieConsent.js
@@ -1,10 +1,15 @@
 function rerunCookieConsentScripts(retries) {
+
+    if (typeof retries === 'undefined') {
+        retries = 0;
+    }
+
     if (retries < 3) {
         try {
             CookieConsent.runScripts();
         } catch(e) {
-            console.log("Cookiebot is undefined: Retry " + retries);
-            setTimeout(() => retryReinitCookieConsent(retries+1), 1000);
+            console.log(`Cookiebot is undefined: Retry ${retries}`);
+            setTimeout(() => rerunCookieConsentScripts(retries+1), 1000);
         }
     }
 }

--- a/docs/versioned_docs/version-0.2.7/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.2.7/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -6,7 +6,7 @@ This tutorial will show you how to zip files on your filesystem and then upload 
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.2.7/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.2.7/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -5,7 +5,9 @@ This tutorial will show you how to zip files on your filesystem and then upload 
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
-
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Setup

--- a/docs/versioned_docs/version-0.3.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.3.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -6,7 +6,7 @@ This tutorial will show you how to zip files on your filesystem and then upload 
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.3.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.3.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -5,7 +5,9 @@ This tutorial will show you how to zip files on your filesystem and then upload 
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
-
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Setup

--- a/docs/versioned_docs/version-0.3.2/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.3.2/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -6,7 +6,7 @@ This tutorial will show you how to zip files on your filesystem and then upload 
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.3.2/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.3.2/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -5,7 +5,9 @@ This tutorial will show you how to zip files on your filesystem and then upload 
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
-
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Setup

--- a/docs/versioned_docs/version-0.4.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.4.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -6,7 +6,7 @@ This tutorial will show you how to zip files on your filesystem and then upload 
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.4.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.4.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -5,7 +5,9 @@ This tutorial will show you how to zip files on your filesystem and then upload 
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
-
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Setup

--- a/docs/versioned_docs/version-0.5.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.5.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -5,7 +5,9 @@ This tutorial will show you how to zip files on your file system and then upload
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
-
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Setup

--- a/docs/versioned_docs/version-0.5.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.5.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -6,7 +6,7 @@ This tutorial will show you how to zip files on your file system and then upload
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.6.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.6.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -6,7 +6,7 @@ This tutorial will show you how to zip files on your file system and then upload
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.6.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.6.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -2,6 +2,12 @@
 
 This tutorial will show you how to zip files on your file system and then upload them to Google Drive.
 
+<div class="cookieconsent-optout-marketing">
+  Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
+</div>
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Setup

--- a/docs/versioned_docs/version-0.6.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.6.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -5,7 +5,9 @@ This tutorial will show you how to zip files on your file system and then upload
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
-
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Setup

--- a/docs/versioned_docs/version-0.6.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.6.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -6,7 +6,7 @@ This tutorial will show you how to zip files on your file system and then upload
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.7.0/general/06-Tutorials/custom-element.md
+++ b/docs/versioned_docs/version-0.7.0/general/06-Tutorials/custom-element.md
@@ -22,6 +22,9 @@ Here we will demonstrate how to use a custom element to explore Google Street Vi
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube.com/watch?v=M00BCweamDc&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Requirements

--- a/docs/versioned_docs/version-0.7.0/general/06-Tutorials/custom-element.md
+++ b/docs/versioned_docs/version-0.7.0/general/06-Tutorials/custom-element.md
@@ -23,7 +23,7 @@ Here we will demonstrate how to use a custom element to explore Google Street Vi
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube.com/watch?v=M00BCweamDc&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.7.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.7.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -10,7 +10,7 @@ This tutorial will show you how to zip files on your file system and then upload
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.7.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.7.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -9,7 +9,9 @@ This tutorial will show you how to zip files on your file system and then upload
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
-
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Setup

--- a/docs/versioned_docs/version-0.7.1/general/06-Tutorials/custom-element.md
+++ b/docs/versioned_docs/version-0.7.1/general/06-Tutorials/custom-element.md
@@ -22,6 +22,9 @@ Here we will demonstrate how to use a custom element to explore Google Street Vi
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube.com/watch?v=M00BCweamDc&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Requirements

--- a/docs/versioned_docs/version-0.7.1/general/06-Tutorials/custom-element.md
+++ b/docs/versioned_docs/version-0.7.1/general/06-Tutorials/custom-element.md
@@ -23,7 +23,7 @@ Here we will demonstrate how to use a custom element to explore Google Street Vi
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube.com/watch?v=M00BCweamDc&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.7.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.7.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -10,7 +10,7 @@ This tutorial will show you how to zip files on your file system and then upload
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.7.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.7.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -9,7 +9,9 @@ This tutorial will show you how to zip files on your file system and then upload
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
-
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Setup

--- a/docs/versioned_docs/version-0.7.2/general/06-Tutorials/custom-element.md
+++ b/docs/versioned_docs/version-0.7.2/general/06-Tutorials/custom-element.md
@@ -22,6 +22,9 @@ Here we will demonstrate how to use a custom element to explore Google Street Vi
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube.com/watch?v=M00BCweamDc&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Requirements

--- a/docs/versioned_docs/version-0.7.2/general/06-Tutorials/custom-element.md
+++ b/docs/versioned_docs/version-0.7.2/general/06-Tutorials/custom-element.md
@@ -23,7 +23,7 @@ Here we will demonstrate how to use a custom element to explore Google Street Vi
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube.com/watch?v=M00BCweamDc&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.7.2/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.7.2/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -10,7 +10,7 @@ This tutorial will show you how to zip files on your file system and then upload
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.7.2/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.7.2/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -9,7 +9,9 @@ This tutorial will show you how to zip files on your file system and then upload
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
-
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Setup

--- a/docs/versioned_docs/version-0.8.0/general/06-Tutorials/custom-element.md
+++ b/docs/versioned_docs/version-0.8.0/general/06-Tutorials/custom-element.md
@@ -22,6 +22,9 @@ Here we will demonstrate how to use a custom element to explore Google Street Vi
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube.com/watch?v=M00BCweamDc&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Requirements

--- a/docs/versioned_docs/version-0.8.0/general/06-Tutorials/custom-element.md
+++ b/docs/versioned_docs/version-0.8.0/general/06-Tutorials/custom-element.md
@@ -23,7 +23,7 @@ Here we will demonstrate how to use a custom element to explore Google Street Vi
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube.com/watch?v=M00BCweamDc&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.8.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.8.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -10,7 +10,7 @@ This tutorial will show you how to zip files on your file system and then upload
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-0.8.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-0.8.0/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -9,7 +9,9 @@ This tutorial will show you how to zip files on your file system and then upload
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
-
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Setup

--- a/docs/versioned_docs/version-v0.10.1/general/06-Tutorials/custom-element.md
+++ b/docs/versioned_docs/version-v0.10.1/general/06-Tutorials/custom-element.md
@@ -22,6 +22,9 @@ Here we will demonstrate how to use a custom element to explore Google Street Vi
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube.com/watch?v=M00BCweamDc&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Requirements

--- a/docs/versioned_docs/version-v0.10.1/general/06-Tutorials/custom-element.md
+++ b/docs/versioned_docs/version-v0.10.1/general/06-Tutorials/custom-element.md
@@ -23,7 +23,7 @@ Here we will demonstrate how to use a custom element to explore Google Street Vi
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube.com/watch?v=M00BCweamDc&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-v0.10.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-v0.10.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -10,7 +10,7 @@ This tutorial will show you how to zip files on your file system and then upload
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
 <div class="cookieconsent-optin-marketing">
-  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+  <a href="javascript:rerunCookieConsentScripts()">Please click to watch this video.</a>
 </div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/versioned_docs/version-v0.10.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
+++ b/docs/versioned_docs/version-v0.10.1/general/06-Tutorials/zip-images-upload-googledrive-windows.md
@@ -9,7 +9,9 @@ This tutorial will show you how to zip files on your file system and then upload
 <div class="cookieconsent-optout-marketing">
   Please <a href="javascript:Cookiebot.renew()">accept marketing-cookies</a> to watch this video.
 </div>
-
+<div class="cookieconsent-optin-marketing">
+  <a href="javascript:rerunCookieConsentScripts(0)">Please click to watch this video.</a>
+</div>
 <iframe width="560" height="315" data-cookieblock-src="https://www.youtube-nocookie.com/embed/i3M5SPYQTKI&embedded=true" data-cookieconsent="marketing" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Setup


### PR DESCRIPTION
So this seems to be the only viable solution to get YouTube videos working with Cookie Consent bot.

The problem is that the CookieConsent Bot is trigger **exactly once** at page load.

Docusaurus is a SPA and does no page reload when you navigate to another side.

But the iframe you want to load when marketing cookies are enabled gets loaded only when you navigate to it (which is not a page refresh).

Thus the Cookie Consent scripts never "see" it and therefore it is disabled.

Solution
---------------
Added a link that triggers a rerun of the Cookie Consent scripts.

Not working Alternatives
---------------
* Add onload event to iframes -> Cookie Consent messes with the HTML of the iframe and removes the onload attribute