### PR TITLE
CL-322 Differentiate correctly between failed and erroneous steps in reporting

### DIFF
--- a/packages/askui-nodejs/src/core/reporting/default-step.ts
+++ b/packages/askui-nodejs/src/core/reporting/default-step.ts
@@ -1,3 +1,4 @@
+import { ControlCommandError } from '../../execution/control-command-error';
 import { Instruction } from './instruction';
 import { Snapshot } from './snapshot';
 import { Step } from './step';
@@ -85,8 +86,11 @@ export class DefaultStep implements Step {
   }
 
   private static determineLastRunStatus(error?: Error): StepStatusEnd {
-    if (error !== undefined) {
+    if (error instanceof ControlCommandError) {
       return 'failed';
+    }
+    if (error !== undefined) {
+      return 'erroneous';
     }
     return 'passed';
   }

--- a/packages/askui-nodejs/src/execution/ui-control-client-error.ts
+++ b/packages/askui-nodejs/src/execution/ui-control-client-error.ts
@@ -1,1 +1,0 @@
-export class UiControlClientError extends Error { }

--- a/packages/askui-nodejs/src/execution/ui-control-client.ts
+++ b/packages/askui-nodejs/src/execution/ui-control-client.ts
@@ -10,7 +10,6 @@ import { AnnotationWriter } from '../core/annotation/annotation-writer';
 import { AnnotationRequest } from '../core/model/annotation-result/annotation-interface';
 import { logger } from '../lib/logger';
 import { AnnotationLevel } from './annotation-level';
-import { UiControlClientError } from './ui-control-client-error';
 import { DetectedElement } from '../core/model/annotation-result/detected-element';
 import { ClientArgs, UiControlClientConfig } from './ui-controller-client-interface';
 import { UiControlClientDependencyBuilder } from './ui-control-client-dependency-builder';
@@ -168,9 +167,7 @@ export class UiControlClient extends ApiCommands {
         instruction,
         error instanceof Error ? error : new Error(String(error)),
       );
-      return Promise.reject(
-        new UiControlClientError(`A problem occurred while executing the instruction: ${instruction.valueHumanReadable}. Reason ${error}`),
-      );
+      return Promise.reject(error);
     }
   }
 

--- a/packages/askui-nodejs/src/execution/ui-controller-client-error.ts
+++ b/packages/askui-nodejs/src/execution/ui-controller-client-error.ts
@@ -1,0 +1,6 @@
+export class UiControllerClientError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'UiControllerClientError';
+    }
+}


### PR DESCRIPTION
- fix(askui-nodejs/reporting): differentiate correctly between failed and erroneous
- fix(askui-nodejs/error-handling): use UiControllerClientError correctly (#CL-322)
