### PR TITLE
docs: use --runInBand CLI-Option in Getting Started guide and reporting

### DIFF
--- a/docs/docs/general/02-Getting Started/write-your-first-instruction.md
+++ b/docs/docs/general/02-Getting Started/write-your-first-instruction.md
@@ -90,8 +90,12 @@ describe('jest with askui', () => {
 To execute the instructions, enter into your terminal
 
 ```shell
-npx jest test/my-first-askui-test-suite.test.ts --config ./test/jest.config.ts 
+npx jest test/my-first-askui-test-suite.test.ts --config ./test/jest.config.ts --runInBand
 ```
+
+:::info
+We use the `--runInBand` CLI option here to run the workflows from the `it`-code blocks sequentially and not in parallel. This is usually what you want on your local machine without isolated environments like containers or VMs.
+:::
 
 A few seconds later an (interactive) annotation will be generated.
 
@@ -145,7 +149,7 @@ describe('jest with askui', () => {
 });
 ````
 
-As before, run your code with `npx jest test/my-first-askui-test-suite.test.ts --config ./test/jest.config.ts `
+As before, run your code with `npx jest test/my-first-askui-test-suite.test.ts --config ./test/jest.config.ts --runInBand`
 
 You should see AskUI take over your mouse, mouse over the element you chose and click.
 

--- a/docs/docs/general/05-Integrations/reporting.md
+++ b/docs/docs/general/05-Integrations/reporting.md
@@ -186,7 +186,7 @@ export default config;
 And run the AskUI suite again:
 
 ```shell
-npx jest test/my-first-askui-test-suite.test.ts --config ./test/jest.config.ts
+npx jest test/my-first-askui-test-suite.test.ts --config ./test/jest.config.ts --runInBand
 ```
 
 By default, **jest-junit** will save the *.xml* report in your project root directory, with the file name **junit.xml**:

--- a/docs/spellchecker-dictionary
+++ b/docs/spellchecker-dictionary
@@ -216,3 +216,5 @@ NTLM
 autostart
 Artifactory
 PNG
+CLI
+VMs

--- a/docs/versioned_docs/version-0.12.2/general/02-Getting Started/write-your-first-instruction.md
+++ b/docs/versioned_docs/version-0.12.2/general/02-Getting Started/write-your-first-instruction.md
@@ -87,11 +87,13 @@ describe('jest with askui', () => {
 });
 ```
 
-To execute the instructions, enter into your terminal
-
 ```shell
-npx jest test/my-first-askui-test-suite.test.ts --config ./test/jest.config.ts 
+npx jest test/my-first-askui-test-suite.test.ts --config ./test/jest.config.ts --runInBand
 ```
+
+:::info
+We use the `--runInBand` CLI option here to run the workflows from the `it`-code blocks sequentially and not in parallel. This is usually what you want on your local machine without isolated environments like containers or VMs.
+:::
 
 A few seconds later an (interactive) annotation will be generated.
 
@@ -145,7 +147,7 @@ describe('jest with askui', () => {
 });
 ````
 
-As before, run your code with `npx jest test/my-first-askui-test-suite.test.ts --config ./test/jest.config.ts `
+As before, run your code with `npx jest test/my-first-askui-test-suite.test.ts --config ./test/jest.config.ts --runInBand`
 
 You should see AskUI take over your mouse, mouse over the element you chose and click.
 

--- a/docs/versioned_docs/version-0.12.2/general/05-Integrations/reporting.md
+++ b/docs/versioned_docs/version-0.12.2/general/05-Integrations/reporting.md
@@ -186,7 +186,7 @@ export default config;
 And run the AskUI suite again:
 
 ```shell
-npx jest test/my-first-askui-test-suite.test.ts --config ./test/jest.config.ts
+npx jest test/my-first-askui-test-suite.test.ts --config ./test/jest.config.ts --runInBand
 ```
 
 By default, **jest-junit** will save the *.xml* report in your project root directory, with the file name **junit.xml**:


### PR DESCRIPTION
I did **not** change the command in all the tutorials as there is no tutorial where we have multiple `it`-blocks.