### PR TITLE
DVRL-51: Install all reporter dependencies as DEV dependencies

### DIFF
--- a/docs/docs/api/09-Remote-Device-Controller.md
+++ b/docs/docs/api/09-Remote-Device-Controller.md
@@ -71,7 +71,7 @@ Make use of our preview build to use the latest features by following the mentio
 
 7. Ensure that in function `afterAll` the controller gets stopped after the ui controller client closes the connection:
 
-        aui.close();
+        aui.disconnect();
         await uiController.stop(true);
 
 8. You should be good to go now to run your workflows as described in documentation.

--- a/docs/docs/general/05-Integrations/containers.md
+++ b/docs/docs/general/05-Integrations/containers.md
@@ -95,7 +95,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  aui.close();
+  aui.disconnect();
 
   await testContainer.stop();
 });

--- a/docs/docs/general/05-Integrations/reporting.md
+++ b/docs/docs/general/05-Integrations/reporting.md
@@ -53,11 +53,16 @@ beforeEach(async () => {
 afterEach(async () => {
   await aui.stopVideoRecording();
   const video = await aui.readVideoRecording();
-  AskUIAllureStepReporter.attachVideo(video);
+  await AskUIAllureStepReporter.attachVideo(video);
 });
 ```
 
 #### Enable the Test Environment `@askui/jest-allure-circus` in `jest.config.ts`
+Install `@askui/jest-allure-circus`` environment:
+
+```bash
+npm install @askui/jest-allure-circus
+```
 
 ```typescript
 import type { Config } from '@jest/types';
@@ -134,7 +139,7 @@ afterEach(async () => {
 Install `jest-html-reporters` environment:
 
 ```bash
-npm install jest-html-reporters
+npm install --save-dev jest-html-reporters
 ```
 
 ```typescript

--- a/docs/docs/general/06-Tutorials/android-search-in-browser.md
+++ b/docs/docs/general/06-Tutorials/android-search-in-browser.md
@@ -98,7 +98,7 @@ beforeAll(async () => {
 afterAll(async () => {
 //   await uiController.stop();
 
-  aui.close();
+  aui.disconnect();
 });
 
 export { aui };

--- a/docs/docs/general/06-Tutorials/flutter-android-sample-app.md
+++ b/docs/docs/general/06-Tutorials/flutter-android-sample-app.md
@@ -169,12 +169,12 @@ beforeAll(async () => {
     });
 
     await aui.connect();
-    });
+});
 
-    afterAll(async () => {
+afterAll(async () => {
     //   await uiController.stop();
 
-    aui.close();
+    aui.disconnect();
 });
 
 export { aui };

--- a/docs/versioned_docs/version-0.10.5/general/06-Tutorials/android-search-in-browser.md
+++ b/docs/versioned_docs/version-0.10.5/general/06-Tutorials/android-search-in-browser.md
@@ -96,7 +96,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-//   await uiController.stop();
+  //   await uiController.stop();
 
   aui.close();
 });

--- a/docs/versioned_docs/version-0.12.0/general/05-Integrations/containers.md
+++ b/docs/versioned_docs/version-0.12.0/general/05-Integrations/containers.md
@@ -95,7 +95,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  aui.close();
+  aui.disconnect();
 
   await testContainer.stop();
 });

--- a/docs/versioned_docs/version-0.12.0/general/06-Tutorials/android-search-in-browser.md
+++ b/docs/versioned_docs/version-0.12.0/general/06-Tutorials/android-search-in-browser.md
@@ -98,7 +98,7 @@ beforeAll(async () => {
 afterAll(async () => {
 //   await uiController.stop();
 
-  aui.close();
+  aui.disconnect();
 });
 
 export { aui };

--- a/docs/versioned_docs/version-0.12.0/general/06-Tutorials/flutter-android-sample-app.md
+++ b/docs/versioned_docs/version-0.12.0/general/06-Tutorials/flutter-android-sample-app.md
@@ -174,7 +174,7 @@ await aui.connect();
 afterAll(async () => {
 //   await uiController.stop();
 
-aui.close();
+aui.disconnect();
 });
 
 export { aui };

--- a/docs/versioned_docs/version-0.12.1/general/05-Integrations/containers.md
+++ b/docs/versioned_docs/version-0.12.1/general/05-Integrations/containers.md
@@ -95,7 +95,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  aui.close();
+  aui.disconnect();
 
   await testContainer.stop();
 });

--- a/docs/versioned_docs/version-0.12.1/general/06-Tutorials/android-search-in-browser.md
+++ b/docs/versioned_docs/version-0.12.1/general/06-Tutorials/android-search-in-browser.md
@@ -98,7 +98,7 @@ beforeAll(async () => {
 afterAll(async () => {
 //   await uiController.stop();
 
-  aui.close();
+  aui.disconnect();
 });
 
 export { aui };

--- a/docs/versioned_docs/version-0.12.1/general/06-Tutorials/flutter-android-sample-app.md
+++ b/docs/versioned_docs/version-0.12.1/general/06-Tutorials/flutter-android-sample-app.md
@@ -174,7 +174,7 @@ await aui.connect();
 afterAll(async () => {
 //   await uiController.stop();
 
-aui.close();
+  aui.disconnect();
 });
 
 export { aui };

--- a/docs/versioned_docs/version-0.12.2/api/09-Remote-Device-Controller.md
+++ b/docs/versioned_docs/version-0.12.2/api/09-Remote-Device-Controller.md
@@ -71,7 +71,7 @@ Make use of our preview build to use the latest features by following the mentio
 
 7. Ensure that in function `afterAll` the controller gets stopped after the ui controller client closes the connection:
 
-        aui.close();
+        aui.disconnect();
         await uiController.stop(true);
 
 8. You should be good to go now to run your workflows as described in documentation.

--- a/docs/versioned_docs/version-0.12.2/general/05-Integrations/containers.md
+++ b/docs/versioned_docs/version-0.12.2/general/05-Integrations/containers.md
@@ -95,7 +95,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  aui.close();
+  aui.disconnect();
 
   await testContainer.stop();
 });

--- a/docs/versioned_docs/version-0.12.2/general/05-Integrations/reporting.md
+++ b/docs/versioned_docs/version-0.12.2/general/05-Integrations/reporting.md
@@ -53,11 +53,16 @@ beforeEach(async () => {
 afterEach(async () => {
   await aui.stopVideoRecording();
   const video = await aui.readVideoRecording();
-  AskUIAllureStepReporter.attachVideo(video);
+  await AskUIAllureStepReporter.attachVideo(video);
 });
 ```
 
 #### Enable the Test Environment `@askui/jest-allure-circus` in `jest.config.ts`
+Install `@askui/jest-allure-circus`` environment:
+
+```bash
+npm install @askui/jest-allure-circus
+```
 
 ```typescript
 import type { Config } from '@jest/types';
@@ -134,7 +139,7 @@ afterEach(async () => {
 Install `jest-html-reporters` environment:
 
 ```bash
-npm install jest-html-reporters
+npm install --save-dev jest-html-reporters
 ```
 
 ```typescript

--- a/docs/versioned_docs/version-0.12.2/general/06-Tutorials/android-search-in-browser.md
+++ b/docs/versioned_docs/version-0.12.2/general/06-Tutorials/android-search-in-browser.md
@@ -98,7 +98,7 @@ beforeAll(async () => {
 afterAll(async () => {
 //   await uiController.stop();
 
-  aui.close();
+  aui.disconnect();
 });
 
 export { aui };

--- a/docs/versioned_docs/version-0.12.2/general/06-Tutorials/flutter-android-sample-app.md
+++ b/docs/versioned_docs/version-0.12.2/general/06-Tutorials/flutter-android-sample-app.md
@@ -172,9 +172,9 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-//   await uiController.stop();
+  //   await uiController.stop();
 
-aui.close();
+  aui.disconnect();
 });
 
 export { aui };

--- a/docs/versioned_docs/version-0.7.2/general/06-Tutorials/flutter-android-sample-app.md
+++ b/docs/versioned_docs/version-0.7.2/general/06-Tutorials/flutter-android-sample-app.md
@@ -174,7 +174,7 @@ await aui.connect();
 afterAll(async () => {
 //   await uiController.stop();
 
-aui.close();
+  aui.close();
 });
 
 export { aui };

--- a/docs/versioned_docs/version-0.8.0/general/06-Tutorials/flutter-android-sample-app.md
+++ b/docs/versioned_docs/version-0.8.0/general/06-Tutorials/flutter-android-sample-app.md
@@ -174,7 +174,7 @@ await aui.connect();
 afterAll(async () => {
 //   await uiController.stop();
 
-aui.close();
+  aui.close();
 });
 
 export { aui };

--- a/packages/askui-nodejs/.eslintrc.js
+++ b/packages/askui-nodejs/.eslintrc.js
@@ -37,19 +37,5 @@ module.exports = {
         'import/no-extraneous-dependencies': ['error', { optionalDependencies: true }],
       },
     },
-    {
-      files: ['example_projects_templates/**/*.ts'],
-      extends: [
-        'plugin:@typescript-eslint/recommended',
-        'airbnb-typescript/base',
-      ],
-      parserOptions: {
-        project: ['./tsconfig.json'],
-        createDefaultProgram: true,
-      },
-      rules: {
-        'import/no-extraneous-dependencies': 'off',
-      },
-    },
   ],
 };

--- a/packages/askui-nodejs/src/lib/interactive_cli/create-example-project.ts
+++ b/packages/askui-nodejs/src/lib/interactive_cli/create-example-project.ts
@@ -103,7 +103,7 @@ export class CreateExampleProject {
       this.helperTemplateConfig['allure_stepreporter_import'] = "import { AskUIAllureStepReporter } from '@askui/askui-reporters';";
       this.helperTemplateConfig['reporter_placeholder'] = 'reporter: new AskUIAllureStepReporter(),';
       this.helperTemplateConfig['allure_stepreporter_attach_video'] = `const video = await aui.readVideoRecording();
-  AskUIAllureStepReporter.attachVideo(video);`;
+  await AskUIAllureStepReporter.attachVideo(video);`;
     }
   }
 


### PR DESCRIPTION
Adapted the docs to reflect this requirement.

Also fixed a bug in the example project:

```typescript
await AskUIAllureStepReporter.attachVideo(video);
```

Instead of

```typescript
AskUIAllureStepReporter.attachVideo(video);
```

The latter causes a weird exception because the execution stops but wants to read something from a non-existing temp folder after stopping.