### PR TITLE
Optimize Vs Integration

### DIFF
--- a/docs/docs/general/02-Components/AskUI-Development-Environment.md
+++ b/docs/docs/general/02-Components/AskUI-Development-Environment.md
@@ -209,16 +209,11 @@ The ADE is build to work seamlessly with (VSCode)[https://code.visualstudio.com/
     "livePreview.customExternalBrowser": "Default",
     "terminal.integrated.profiles.windows":{   
         "askui-shell": {    
-            "path": ["C:\\Program Files\\AskUI GmbH\\AskUI Suite\\Tools\\askui-shell.cmd"],
-            "args": [
-               "activate"
-            ],
-            "icon": "terminal-bash",
-        },        
-        "Git Bash": null,        
-        "Command Prompt": null,        
-        "PowerShell": null,        
-        "JavaScript Debug Terminal": null
+            "path": ["${env:ASKUI_INSTALLATION_DIRECTORY}\\Tools\\askui-shell.cmd"],
+            "icon": "robot",
+            "overrideName": true,
+            "color": "terminal.ansiMagenta",
+        }
     },
     "terminal.integrated.defaultProfile.windows": "askui-shell"
 }

--- a/docs/docs/general/02-Components/AskUI-Development-Environment.md
+++ b/docs/docs/general/02-Components/AskUI-Development-Environment.md
@@ -219,7 +219,7 @@ The ADE is build to work seamlessly with (VSCode)[https://code.visualstudio.com/
 }
 ```
 
-- `terminal.integrated.profiles.windows`: Configures the `askui-shell` and deactivates other shells
+- `terminal.integrated.profiles.windows`: Configures the `askui-shell
 - `terminal.integrated.defaultProfile.windows`: Sets the `askui-shell` as default
 
 Then the `askui-shell` is configured as the default terminal like this:

--- a/docs/versioned_docs/version-0.14.0/general/02-Components/AskUI-Development-Environment.md
+++ b/docs/versioned_docs/version-0.14.0/general/02-Components/AskUI-Development-Environment.md
@@ -209,16 +209,11 @@ The ADE is build to work seamlessly with (VSCode)[https://code.visualstudio.com/
     "livePreview.customExternalBrowser": "Default",
     "terminal.integrated.profiles.windows":{   
         "askui-shell": {    
-            "path": ["C:\\Program Files\\AskUI GmbH\\AskUI Suite\\Tools\\askui-shell.cmd"],
-            "args": [
-               "activate"
-            ],
-            "icon": "terminal-bash",
-        },        
-        "Git Bash": null,        
-        "Command Prompt": null,        
-        "PowerShell": null,        
-        "JavaScript Debug Terminal": null
+            "path": ["${env:ASKUI_INSTALLATION_DIRECTORY}\\Tools\\askui-shell.cmd"],
+            "icon": "robot",
+            "overrideName": true,
+            "color": "terminal.ansiMagenta",
+        }
     },
     "terminal.integrated.defaultProfile.windows": "askui-shell"
 }


### PR DESCRIPTION
- Eliminate the hardcoded askui-shell.cmd file path.
- Retain the option for other terminals to remain enabled, as it should be the user's decision.
- Enable "overrideName" to ensure the terminal title consistently displays as askui-shell.
- Update the icon to a robot and apply a magenta color to match the askui theme.

![image](https://github.com/askui/askui/assets/105347215/c90f9fc7-9105-4e45-9c7a-604b8842ac2b)
