### PR TITLE
revert: readd --test-framework option for interactive CLI for backwards compatibility (#DVRL-72)

### DIFF
--- a/packages/askui-nodejs/src/lib/interactive_cli/cli-options-interface.ts
+++ b/packages/askui-nodejs/src/lib/interactive_cli/cli-options-interface.ts
@@ -2,6 +2,7 @@ export interface CliOptions {
   operatingSystem: 'windows' | 'linux' | 'macos',
   workspaceId: string,
   accessToken: string,
+  testFramework: 'jest',
   usingProxy: boolean,
   typescriptConfig: boolean,
 }

--- a/packages/askui-nodejs/src/lib/interactive_cli/cli.ts
+++ b/packages/askui-nodejs/src/lib/interactive_cli/cli.ts
@@ -9,7 +9,7 @@ const questions = [
   {
     type: 'list',
     name: 'testFramework',
-    message: 'Which framework do you prefer',
+    message: 'Which framework do you prefer?',
     choices: ['jest'],
   },
   {

--- a/packages/askui-nodejs/src/lib/interactive_cli/cli.ts
+++ b/packages/askui-nodejs/src/lib/interactive_cli/cli.ts
@@ -7,6 +7,12 @@ const nonEmpty = (subject: string) => (input: string) => (input.trim().length > 
 
 const questions = [
   {
+    type: 'list',
+    name: 'testFramework',
+    message: 'Which framework do you prefer',
+    choices: ['jest'],
+  },
+  {
     type: 'input',
     name: 'workspaceId',
     message: 'Your workspace id',
@@ -34,6 +40,11 @@ const questions = [
 ];
 
 const options = [
+  {
+    option: '-f, --test-framework <value>',
+    choices: ['jest'],
+    description: 'the test framework to use',
+  },
   {
     option: '-w, --workspace-id <value>',
     choices: [],
@@ -66,7 +77,7 @@ export function init(argv: string[]): Command {
   const args = argv || process.argv;
   const program = createProgram();
   const programInit = program.command('init');
-  programInit.description('Creates a askui example project');
+  programInit.description('Creates an askui example project');
 
   // Loop through the options object and register each option with the program
   options.forEach((opt) => {


### PR DESCRIPTION
Hello @mlikasam-askui 

This readds the `--test-framework` option to the interactive CLI again.