### PR TITLE
feat(ML-492): use V4 online learning endpoint.

### DIFF
--- a/packages/askui-nodejs/src/execution/inference-client.ts
+++ b/packages/askui-nodejs/src/execution/inference-client.ts
@@ -27,7 +27,7 @@ export class InferenceClient {
     private readonly resize?: number,
     readonly workspaceId?: string,
     readonly modelComposition?: ModelCompositionBranch[],
-    private readonly apiVersion = 'v4',
+    private readonly apiVersion = 'v3',
   ) {
     const versionedBaseUrl = urljoin(this.baseUrl, 'api', this.apiVersion);
     const url = workspaceId

--- a/packages/askui-nodejs/src/execution/inference-client.ts
+++ b/packages/askui-nodejs/src/execution/inference-client.ts
@@ -48,11 +48,6 @@ export class InferenceClient {
   }
 
   async isImageRequired(instruction: string): Promise<boolean> {
-    // V4's image is always required
-    if (this.urls.inference.endsWith('predict')) {
-      return true;
-    }
-
     const response = await this.httpClient.post<IsImageRequired>(
       this.urls.isImageRequired,
       {

--- a/packages/askui-nodejs/src/execution/inference-client.ts
+++ b/packages/askui-nodejs/src/execution/inference-client.ts
@@ -48,9 +48,9 @@ export class InferenceClient {
   }
 
   async isImageRequired(instruction: string): Promise<boolean> {
-    // V4's image is not required
+    // V4's image is always required
     if (this.urls.inference.endsWith('predict')) {
-      return false;
+      return true;
     }
 
     const response = await this.httpClient.post<IsImageRequired>(
@@ -83,7 +83,7 @@ export class InferenceClient {
       this.urls.inference,
       this.urls.inference.endsWith('predict') ? {
         // V4 only supports the base64 image and not the metadata of the base64 string
-        image: resizedImage.base64Image?.split(',')[1],
+        image: resizedImage.base64Image,
         instruction,
         tasks: ['OCR'],
       }

--- a/packages/askui-nodejs/src/execution/inference-client.ts
+++ b/packages/askui-nodejs/src/execution/inference-client.ts
@@ -27,7 +27,7 @@ export class InferenceClient {
     private readonly resize?: number,
     readonly workspaceId?: string,
     readonly modelComposition?: ModelCompositionBranch[],
-    private readonly apiVersion = 'v3',
+    private readonly apiVersion = 'v4',
   ) {
     const versionedBaseUrl = urljoin(this.baseUrl, 'api', this.apiVersion);
     const url = workspaceId

--- a/packages/askui-nodejs/src/execution/inference-client.ts
+++ b/packages/askui-nodejs/src/execution/inference-client.ts
@@ -35,7 +35,7 @@ export class InferenceClient {
       : versionedBaseUrl;
     this.urls = {
       // V4's only end part is different
-      inference: apiVersion === 'v4'? urljoin(url, 'predict') : urljoin(url, 'inference'),
+      inference: apiVersion === 'v4' ? urljoin(url, 'predict') : urljoin(url, 'inference'),
       isImageRequired: urljoin(url, 'instruction', 'is-image-required'),
     };
     this.httpClient.urlsToRetry = Object.values(this.urls);
@@ -49,9 +49,9 @@ export class InferenceClient {
 
   async isImageRequired(instruction: string): Promise<boolean> {
     // V4's image is not required
-    if(this.urls.inference.endsWith("predict")){
+    if (this.urls.inference.endsWith('predict')) {
       return false;
-    }    
+    }
 
     const response = await this.httpClient.post<IsImageRequired>(
       this.urls.isImageRequired,
@@ -81,18 +81,18 @@ export class InferenceClient {
     const resizedImage = await this.resizeIfNeeded(customElements, image);
     const response = await this.httpClient.post<InferenceResponseBody>(
       this.urls.inference,
-      this.urls.inference.endsWith("predict") ? {
+      this.urls.inference.endsWith('predict') ? {
         // V4 only supports the base64 image and not the metadata of the base64 string
-        image: resizedImage.base64Image?.split(",")[1],
+        image: resizedImage.base64Image?.split(',')[1],
         instruction,
-        tasks: ["OCR"]
-      }:
-      {
-        customElements,
-        image: resizedImage.base64Image,
-        instruction,
-        modelComposition: this.modelComposition,
-      },
+        tasks: ['OCR'],
+      }
+        : {
+          customElements,
+          image: resizedImage.base64Image,
+          instruction,
+          modelComposition: this.modelComposition,
+        },
     );
     InferenceClient.logMetaInformation(response);
     return InferenceResponse.fromJson(

--- a/packages/askui-nodejs/src/execution/inference-client.ts
+++ b/packages/askui-nodejs/src/execution/inference-client.ts
@@ -34,8 +34,7 @@ export class InferenceClient {
       ? urljoin(versionedBaseUrl, 'workspaces', workspaceId)
       : versionedBaseUrl;
     this.urls = {
-      // V4's only end part is different
-      inference: apiVersion === 'v4' ? urljoin(url, 'predict') : urljoin(url, 'inference'),
+      inference: apiVersion === 'v4-experimental' ? urljoin(url, 'predict') : urljoin(url, 'inference'),
       isImageRequired: urljoin(url, 'instruction', 'is-image-required'),
     };
     this.httpClient.urlsToRetry = Object.values(this.urls);
@@ -77,7 +76,6 @@ export class InferenceClient {
     const response = await this.httpClient.post<InferenceResponseBody>(
       this.urls.inference,
       this.urls.inference.endsWith('predict') ? {
-        // V4 only supports the base64 image and not the metadata of the base64 string
         image: resizedImage.base64Image,
         instruction,
         tasks: ['OCR'],

--- a/packages/askui-nodejs/src/execution/inference-client.ts
+++ b/packages/askui-nodejs/src/execution/inference-client.ts
@@ -34,7 +34,7 @@ export class InferenceClient {
       ? urljoin(versionedBaseUrl, 'workspaces', workspaceId)
       : versionedBaseUrl;
     this.urls = {
-      inference: apiVersion === 'v4-experimental' ? urljoin(url, 'predict') : urljoin(url, 'inference'),
+      inference: urljoin(url, 'inference'),
       isImageRequired: urljoin(url, 'instruction', 'is-image-required'),
     };
     this.httpClient.urlsToRetry = Object.values(this.urls);
@@ -75,7 +75,7 @@ export class InferenceClient {
     const resizedImage = await this.resizeIfNeeded(customElements, image);
     const response = await this.httpClient.post<InferenceResponseBody>(
       this.urls.inference,
-      this.urls.inference.endsWith('predict') ? {
+      this.urls.inference.includes('v4-experimental') ? {
         image: resizedImage.base64Image,
         instruction,
         tasks: ['OCR'],

--- a/packages/askui-nodejs/src/execution/ui-control-client-dependency-builder.ts
+++ b/packages/askui-nodejs/src/execution/ui-control-client-dependency-builder.ts
@@ -75,10 +75,10 @@ export class UiControlClientDependencyBuilder {
         isCi: clientArgs.context?.isCi ?? isCI,
       },
       credentials: readCredentials(clientArgs),
+      inferenceServerApiVersion: clientArgs.inferenceServerApiVersion ?? 'v3',
       inferenceServerUrl:
         clientArgs.inferenceServerUrl ?? 'https://inference.askui.com',
       proxyAgents: clientArgs.proxyAgents ?? (await envProxyAgents()),
-      inferenceServerApiVersion: clientArgs.inferenceServerApiVersion ?? 'v3',
       uiControllerUrl: clientArgs.uiControllerUrl ?? 'http://127.0.0.1:6769',
     };
   }

--- a/packages/askui-nodejs/src/execution/ui-control-client-dependency-builder.ts
+++ b/packages/askui-nodejs/src/execution/ui-control-client-dependency-builder.ts
@@ -78,8 +78,8 @@ export class UiControlClientDependencyBuilder {
       inferenceServerUrl:
         clientArgs.inferenceServerUrl ?? 'https://inference.askui.com',
       proxyAgents: clientArgs.proxyAgents ?? (await envProxyAgents()),
-      uiControllerUrl: clientArgs.uiControllerUrl ?? 'http://127.0.0.1:6769',
       inferenceServerApiVersion: clientArgs.inferenceServerApiVersion ?? 'v3',
+      uiControllerUrl: clientArgs.uiControllerUrl ?? 'http://127.0.0.1:6769',
     };
   }
 }

--- a/packages/askui-nodejs/src/execution/ui-control-client-dependency-builder.ts
+++ b/packages/askui-nodejs/src/execution/ui-control-client-dependency-builder.ts
@@ -39,7 +39,7 @@ export class UiControlClientDependencyBuilder {
       clientArgs.resize,
       clientArgs.credentials?.workspaceId,
       clientArgs.modelComposition,
-      clientArgs.inferenceServerApiVersion
+      clientArgs.inferenceServerApiVersion,
     );
   }
 
@@ -79,7 +79,7 @@ export class UiControlClientDependencyBuilder {
         clientArgs.inferenceServerUrl ?? 'https://inference.askui.com',
       proxyAgents: clientArgs.proxyAgents ?? (await envProxyAgents()),
       uiControllerUrl: clientArgs.uiControllerUrl ?? 'http://127.0.0.1:6769',
-      inferenceServerApiVersion: clientArgs.inferenceServerApiVersion ?? 'v3'
+      inferenceServerApiVersion: clientArgs.inferenceServerApiVersion ?? 'v3',
     };
   }
 }

--- a/packages/askui-nodejs/src/execution/ui-control-client-dependency-builder.ts
+++ b/packages/askui-nodejs/src/execution/ui-control-client-dependency-builder.ts
@@ -39,6 +39,7 @@ export class UiControlClientDependencyBuilder {
       clientArgs.resize,
       clientArgs.credentials?.workspaceId,
       clientArgs.modelComposition,
+      clientArgs.inferenceServerApiVersion
     );
   }
 
@@ -78,6 +79,7 @@ export class UiControlClientDependencyBuilder {
         clientArgs.inferenceServerUrl ?? 'https://inference.askui.com',
       proxyAgents: clientArgs.proxyAgents ?? (await envProxyAgents()),
       uiControllerUrl: clientArgs.uiControllerUrl ?? 'http://127.0.0.1:6769',
+      inferenceServerApiVersion: clientArgs.inferenceServerApiVersion ?? 'v3'
     };
   }
 }

--- a/packages/askui-nodejs/src/execution/ui-controller-client-interface.ts
+++ b/packages/askui-nodejs/src/execution/ui-controller-client-interface.ts
@@ -55,10 +55,12 @@ export interface ClientArgs {
   readonly modelComposition?: ModelCompositionBranch[]
   readonly reporter?: Reporter | Reporter[] | undefined
   readonly context?: ContextArgs | undefined
+  readonly inferenceServerApiVersion?: string
 }
 
 export interface ClientArgsWithDefaults extends ClientArgs {
   readonly uiControllerUrl: string
   readonly inferenceServerUrl: string
   readonly context: Context
+  readonly inferenceServerApiVersion: string
 }


### PR DESCRIPTION
# Description

Supports the v4 version of online learning of inference. Backward compatible.

# Tested on
- Local test with only using adding "inferenceServerApiVersion" as "v4" inside UiControlClient.build({})
- Used Dart application to train the model
- Call the test case again and annotate in html if the difference is there