### PR TITLE
feat: change eslint-rule-askui to @askui/eslint-rule-askui; Activate the rule for expect

### DIFF
--- a/packages/askui-nodejs/example_projects_templates/typescript/.eslintrc.json-template
+++ b/packages/askui-nodejs/example_projects_templates/typescript/.eslintrc.json-template
@@ -15,7 +15,7 @@
     "@askui/askui"
   ],
   "rules": {
-      "@askui/askui/no-missing-askui-exec": "error",
-      "@askui/askui/correct-askui-expect-usage": "error"
+      "@askui/askui/no-missing-exec": "error",
+      "@askui/askui/expect": "error"
   }
 }

--- a/packages/askui-nodejs/example_projects_templates/typescript/.eslintrc.json-template
+++ b/packages/askui-nodejs/example_projects_templates/typescript/.eslintrc.json-template
@@ -12,9 +12,10 @@
   },
   "plugins": [
     "import",
-    "askui"
+    "@askui/askui"
   ],
   "rules": {
-      "askui/no-missing-askui-exec": "error"
+      "@askui/askui/no-missing-askui-exec": "error",
+      "@askui/askui/correct-askui-expect-usage": "error"
   }
 }

--- a/packages/askui-nodejs/src/lib/interactive_cli/create-example-project.ts
+++ b/packages/askui-nodejs/src/lib/interactive_cli/create-example-project.ts
@@ -207,7 +207,7 @@ export class CreateExampleProject {
   private static async installTestFrameworkPackages(): Promise<void> {
     const runCommand = promisify(exec);
     const frameworkDependencies = {
-      jest: 'npm i -D @askui/askui-reporters typescript ts-node @types/jest ts-jest jest @askui/jest-allure-circus eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-plugin-import eslint-plugin-askui hpagent',
+      jest: 'npm i -D @askui/askui-reporters typescript ts-node @types/jest ts-jest jest @askui/jest-allure-circus eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-plugin-import @askui/eslint-plugin-askui hpagent',
     };
     await runCommand(frameworkDependencies.jest);
   }


### PR DESCRIPTION
* Activate the new ESLint rule for correct `expect()` instructions
* Noticed we still had the old dependency reference (not in @askui org) when we `init` askui. Changed it to the org one.