### PR TITLE
feat(ML-492): use experimental flag to plugin trained ocr model

### DIFF
--- a/packages/askui-nodejs/src/execution/experimental-flags.ts
+++ b/packages/askui-nodejs/src/execution/experimental-flags.ts
@@ -1,0 +1,3 @@
+export interface ExperimentalFlags {
+  useTrainedOCR: boolean
+}

--- a/packages/askui-nodejs/src/execution/inference-client.ts
+++ b/packages/askui-nodejs/src/execution/inference-client.ts
@@ -12,6 +12,7 @@ import { ConfigurationError } from './config-error';
 import { InferenceResponseBody } from '../core/inference-response/inference-response';
 import { logger } from '../lib/logger';
 import { ModelCompositionBranch } from './model-composition-branch';
+import { ExperimentalFlags } from './experimental-flags';
 
 interface InferenceClientUrls {
   inference: string;
@@ -27,6 +28,7 @@ export class InferenceClient {
     private readonly resize?: number,
     readonly workspaceId?: string,
     readonly modelComposition?: ModelCompositionBranch[],
+    readonly experimentalFlags?: ExperimentalFlags,
     private readonly apiVersion = 'v3',
   ) {
     const versionedBaseUrl = urljoin(this.baseUrl, 'api', this.apiVersion);
@@ -77,6 +79,7 @@ export class InferenceClient {
       this.urls.inference,
       {
         customElements,
+        experimentalFlags: this.experimentalFlags,
         image: resizedImage.base64Image,
         instruction,
         modelComposition: this.modelComposition,

--- a/packages/askui-nodejs/src/execution/ui-control-client-dependency-builder.ts
+++ b/packages/askui-nodejs/src/execution/ui-control-client-dependency-builder.ts
@@ -39,6 +39,7 @@ export class UiControlClientDependencyBuilder {
       clientArgs.resize,
       clientArgs.credentials?.workspaceId,
       clientArgs.modelComposition,
+      clientArgs.experimentalFlags,
     );
   }
 
@@ -74,6 +75,7 @@ export class UiControlClientDependencyBuilder {
         isCi: clientArgs.context?.isCi ?? isCI,
       },
       credentials: readCredentials(clientArgs),
+      experimentalFlags: clientArgs.experimentalFlags ?? { useTrainedOCR: false },
       inferenceServerUrl:
         clientArgs.inferenceServerUrl ?? 'https://inference.askui.com',
       proxyAgents: clientArgs.proxyAgents ?? (await envProxyAgents()),

--- a/packages/askui-nodejs/src/execution/ui-controller-client-interface.ts
+++ b/packages/askui-nodejs/src/execution/ui-controller-client-interface.ts
@@ -3,6 +3,7 @@ import { ProxyAgentArgs } from '../shared/proxy-agent-args';
 import { ModelCompositionBranch } from './model-composition-branch';
 import { Reporter } from '../core/reporting';
 import { Context } from './context';
+import { ExperimentalFlags } from './experimental-flags';
 
 /**
  * Context object to provide additional information about the context of (test) automation.
@@ -55,10 +56,12 @@ export interface ClientArgs {
   readonly modelComposition?: ModelCompositionBranch[]
   readonly reporter?: Reporter | Reporter[] | undefined
   readonly context?: ContextArgs | undefined
+  readonly experimentalFlags?: ExperimentalFlags
 }
 
 export interface ClientArgsWithDefaults extends ClientArgs {
   readonly uiControllerUrl: string
   readonly inferenceServerUrl: string
   readonly context: Context
+  readonly experimentalFlags: ExperimentalFlags
 }


### PR DESCRIPTION
# Description

Supports the experimental feature of online learning of inference. Backward compatible.

# Tested on
- Local test with not providing "experimentalFlags" inside UiControlClient.build({})
- Local test with only using adding nested "experimentalFlags" value "useTrainedOCR" as true inside UiControlClient.build({})
- Local test with only using adding nested "experimentalFlags" value "useTrainedOCR" as false inside UiControlClient.build({})
- Call the test case again and annotate in html if the difference is there

## To Test
- Used Dart application to train the model