### PR TITLE
CL-728 Track askui client id and client session id

### DIFF
--- a/packages/askui-nodejs/src/utils/analytics/analytics.ts
+++ b/packages/askui-nodejs/src/utils/analytics/analytics.ts
@@ -1,4 +1,5 @@
 import os from 'os';
+import crypto from 'crypto';
 import { AnalyticsInterface } from './analytics-interface';
 import { UserIdentifierInterface } from './user-identifier-interface';
 import { UserIdentifier } from './user-identifier';
@@ -6,11 +7,14 @@ import { InstallationTimestamp } from './installation-timestamp';
 import { Context } from '@/execution/context';
 
 export class Analytics implements AnalyticsInterface {
+  private static clientSessionId: string = crypto.randomUUID();
+
   private userIdentifier: UserIdentifierInterface = new UserIdentifier();
 
   async getAnalyticsHeaders(context: Context): Promise<Record<string, string>> {
     const userID = await this.userIdentifier.userId();
     const headers: Record<string, string> = {
+      'askui-client-session-id': Analytics.clientSessionId,
       'askui-is-ci': String(context.isCi),
       'askui-user-agent': `os:${os.platform()};arch:${os.arch()}`,
       'askui-user-id': userID,

--- a/packages/askui-nodejs/src/utils/analytics/analytics.ts
+++ b/packages/askui-nodejs/src/utils/analytics/analytics.ts
@@ -9,11 +9,14 @@ import { Context } from '@/execution/context';
 export class Analytics implements AnalyticsInterface {
   private static clientSessionId: string = crypto.randomUUID();
 
+  private clientId: string = crypto.randomUUID();
+
   private userIdentifier: UserIdentifierInterface = new UserIdentifier();
 
   async getAnalyticsHeaders(context: Context): Promise<Record<string, string>> {
     const userID = await this.userIdentifier.userId();
     const headers: Record<string, string> = {
+      'askui-client-id': this.clientId,
       'askui-client-session-id': Analytics.clientSessionId,
       'askui-is-ci': String(context.isCi),
       'askui-user-agent': `os:${os.platform()};arch:${os.arch()}`,


### PR DESCRIPTION
- Client id: Id of instance of the `UiControlClient` created at runtime
- Client session id: Id of session (e.g., started by `npm run test`) in which client is used

Limitation: Session id currently different for each process if user decides to parallelise with worker processes