### PR TITLE
feat: convenience method expectAllExist() for checking if multiple elements are detected (#APD-483)

### DIFF
--- a/packages/askui-nodejs/src/execution/index.ts
+++ b/packages/askui-nodejs/src/execution/index.ts
@@ -1,7 +1,6 @@
 export {
   UiControlClient,
   RelationsForConvenienceMethods,
-  ExpectExistenceAllowedElementClasses,
   ExpectExistenceInputParameter,
   ExpectExistenceReturnValue,
 } from './ui-control-client';

--- a/packages/askui-nodejs/src/execution/index.ts
+++ b/packages/askui-nodejs/src/execution/index.ts
@@ -1,6 +1,1 @@
-export {
-  UiControlClient,
-  RelationsForConvenienceMethods,
-  ExpectExistenceInputParameter,
-  ExpectExistenceReturnValue,
-} from './ui-control-client';
+export * from './ui-control-client';

--- a/packages/askui-nodejs/src/execution/index.ts
+++ b/packages/askui-nodejs/src/execution/index.ts
@@ -1,1 +1,7 @@
-export { UiControlClient, RelationsForConvenienceMethods } from './ui-control-client';
+export {
+  UiControlClient,
+  RelationsForConvenienceMethods,
+  ExpectExistenceAllowedElementClasses,
+  ExpectExistenceInputParameter,
+  ExpectExistenceReturnValue,
+} from './ui-control-client';

--- a/packages/askui-nodejs/src/execution/ui-control-client.ts
+++ b/packages/askui-nodejs/src/execution/ui-control-client.ts
@@ -21,7 +21,7 @@ import { Instruction, StepReporter } from '../core/reporting';
 export type RelationsForConvenienceMethods = 'nearestTo' | 'leftOf' | 'above' | 'rightOf' | 'below' | 'contains';
 
 export type ExpectExistenceAllowedElementClasses = 'text' | 'button' | 'checkbox' | 'switch' | 'textfield' | 'element';
-export type ExpectExistenceInputParameter = {
+export interface ExpectExistenceInputParameter {
   type: ExpectExistenceAllowedElementClasses;
   label: string;
   matching?: 'similar' | 'exact' | 'regex';
@@ -29,11 +29,13 @@ export type ExpectExistenceInputParameter = {
     type: RelationsForConvenienceMethods;
     text?: string;
   };
-  exists?: boolean;
 };
+export interface ExpectExistenceElement extends ExpectExistenceInputParameter {
+  exists: boolean;
+}
 export type ExpectExistenceReturnValue = {
   everythingExists: boolean;
-  elements: ExpectExistenceInputParameter[];
+  elements: ExpectExistenceElement[];
 };
 
 export class UiControlClient extends ApiCommands {
@@ -624,16 +626,11 @@ export class UiControlClient extends ApiCommands {
   // eslint-disable-next-line class-methods-use-this
   private async evaluateFinalExpectExistenceCommand(
     finalCommand: FluentFiltersOrRelationsGetter,
-    element: ExpectExistenceInputParameter,
-  ): Promise<ExpectExistenceInputParameter> {
-    const el = element;
-    el.exists = false;
+  ): Promise<boolean> {
     if ((await finalCommand.exec()).length > 0) {
-      el.exists = true;
+      return true;
     }
-    return new Promise<ExpectExistenceInputParameter>((resolve) => {
-      resolve(el);
-    });
+    return false;
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -767,7 +764,7 @@ export class UiControlClient extends ApiCommands {
           }
 
           returnValue.elements.push(
-            (await this.evaluateFinalExpectExistenceCommand(finalCommand, element)),
+            {...element, exists: await this.evaluateFinalExpectExistenceCommand(finalCommand)},
           );
           break;
         }
@@ -788,7 +785,7 @@ export class UiControlClient extends ApiCommands {
           }
 
           returnValue.elements.push(
-            (await this.evaluateFinalExpectExistenceCommand(finalCommand, element)),
+            {...element, exists: await this.evaluateFinalExpectExistenceCommand(finalCommand)},
           );
           break;
         }
@@ -807,7 +804,7 @@ export class UiControlClient extends ApiCommands {
           }
 
           returnValue.elements.push(
-            (await this.evaluateFinalExpectExistenceCommand(finalCommand, element)),
+            {...element, exists: await this.evaluateFinalExpectExistenceCommand(finalCommand)},
           );
           break;
         }
@@ -834,7 +831,7 @@ export class UiControlClient extends ApiCommands {
           }
 
           returnValue.elements.push(
-            (await this.evaluateFinalExpectExistenceCommand(finalCommand, element)),
+            {...element, exists: await this.evaluateFinalExpectExistenceCommand(finalCommand)},
           );
           break;
         }

--- a/packages/askui-nodejs/src/execution/ui-control-client.ts
+++ b/packages/askui-nodejs/src/execution/ui-control-client.ts
@@ -4,7 +4,6 @@ import {
   Exec,
   Executable,
   FluentFilters,
-  FluentFiltersGetter,
   ApiCommands,
   Separators,
   PC_AND_MODIFIER_KEY,
@@ -621,11 +620,19 @@ export class UiControlClient extends ApiCommands {
     await command.exec();
   }
 
+  private evaluateMatchingProperty(
+    command: FluentFiltersOrRelations,
+    text: ExpectExistenceInputParameterText,
+  ): FluentFiltersOrRelations;
+  private evaluateMatchingProperty(
+    command: FluentFiltersOrRelationsGetter,
+    text: ExpectExistenceInputParameterText,
+  ): FluentFiltersOrRelationsGetter;
   // eslint-disable-next-line class-methods-use-this
   private evaluateMatchingProperty(
-    command: FluentFiltersGetter | FluentFiltersOrRelationsGetter | FluentFiltersOrRelations,
+    command: FluentFiltersOrRelations | FluentFiltersOrRelationsGetter,
     text: ExpectExistenceInputParameterText,
-  ): FluentFiltersOrRelationsGetter | FluentFiltersOrRelations {
+  ): FluentFiltersOrRelations | FluentFiltersOrRelationsGetter {
     switch (text.matching ?? 'similar') {
       case 'exact':
         return command.withExactText(text.value);
@@ -702,7 +709,7 @@ export class UiControlClient extends ApiCommands {
       const acc = await accumulatorPromise;
       const command = this.get()[param.type]();
       let finalCommand = param.text !== undefined
-        ? this.evaluateMatchingProperty(command, param.text) as FluentFiltersOrRelationsGetter
+        ? this.evaluateMatchingProperty(command, param.text)
         : command;
       if (param.relation) {
         finalCommand = this.evaluateRelation(

--- a/packages/askui-nodejs/src/execution/ui-control-client.ts
+++ b/packages/askui-nodejs/src/execution/ui-control-client.ts
@@ -576,15 +576,15 @@ export class UiControlClient extends ApiCommands {
    * **Examples:**
    * ```typescript
    * // Click text that matches exactly
-   * await aui.clickText({text: 'askui', type: 'similar'})
+   * await aui.clickText({text: 'askui', matching: 'similar'})
    *
    * // Click text that contains 'pie' or 'cake' or 'Pie' or 'Cake'
-   * await aui.clickText({text: '.*([Pp]ie|[Cc]ake).*', type: 'regex'})
+   * await aui.clickText({text: '.*([Pp]ie|[Cc]ake).*', matching: 'regex'})
    *
    * // Click the text 'TERMINAL' that is left of the text 'Ports'
    * await aui.clickText({
    *     text: 'TERMINAL',
-   *     type: "exact",
+   *     matching: "exact",
    *     relation: { type: 'leftOf', text: 'PORTS' }
    *   })
    * ```
@@ -593,7 +593,7 @@ export class UiControlClient extends ApiCommands {
    *                          for regular expression matching and relation.
    * @property {string} params.text - The text to be clicked.
    * @property {string} params.matching - Whether the text is matched using similarity,
-   *                                  exact match or a regular expression.
+   *                                      exact match or a regular expression.
    * @property {Object} params.relation - Object describing the relationship between the
    *                                      clicked text and another element.
    * @property {RelationsForConvenienceMethods} params.relation.type - The type of relation.
@@ -683,7 +683,7 @@ export class UiControlClient extends ApiCommands {
    * @property {string} params.type - The type of the element: 'otherElement' | 'switch' |
    *                                  'element' | 'container' | 'checkbox' | 'element' |
    *                                  'button' | 'table' | 'text' | 'icon' | 'image' | 'textfield'
-   * @property {Object} params.text - Object containing value and matching strategy
+   * @property {Object} params.text - Object containing value and matching strategy.
    * @property {string} params.text.value - The text to match for.
    * @property {string} params.text.matching - Whether the text is matched using similarity,
    *                                           exact match or a regular expression.

--- a/packages/askui-nodejs/src/execution/ui-control-client.ts
+++ b/packages/askui-nodejs/src/execution/ui-control-client.ts
@@ -684,11 +684,7 @@ export class UiControlClient extends ApiCommands {
   }
 
   /**
-   * Click on a specific text.
-   * You can also use a RegEx or match the text exactly by specifying the specific flag.
-   * Use a relation to find the text in relation to a specific text.
-   *
-   * The return value contains a boolean property 'everythingExists'
+   * Check if one or multiple elements are detected.
    *
    * **Examples:**
    * ```typescript

--- a/packages/askui-nodejs/src/execution/ui-control-client.ts
+++ b/packages/askui-nodejs/src/execution/ui-control-client.ts
@@ -711,7 +711,7 @@ export class UiControlClient extends ApiCommands {
    *                                            exact match or a regular expression.
    * @property {Object} [query.relation] - Object describing the relationship between the
    *                                       clicked text and another element.
-   * @property {RelationsForConvenienceMethods} params.relation.type - The type of relation.
+   * @property {RelationsForConvenienceMethods} query.relation.type - The type of relation.
    * @property {string} query.relation.text - The label or text associated with the
    *                                          related element or state.
    * @returns {ExpectAllExistResult.allExist} - If every element exists.

--- a/packages/askui-nodejs/src/execution/ui-control-client.ts
+++ b/packages/askui-nodejs/src/execution/ui-control-client.ts
@@ -692,7 +692,7 @@ export class UiControlClient extends ApiCommands {
    *
    * // Validate existence
    * const exists = await aui.expectAllExist([...]);
-   * exists.everythingExists // true when every element exists
+   * exists.allExist // true when every element exists
    *
    * // Check which elements do not exist
    * // with the elements property
@@ -714,7 +714,7 @@ export class UiControlClient extends ApiCommands {
    * @property {RelationsForConvenienceMethods} params.relation.type - The type of relation.
    * @property {string} query.relation.text - The label or text associated with the
    *                                          related element or state.
-   * @returns {ExpectAllExistResult.everythingExists} - If every element exists.
+   * @returns {ExpectAllExistResult.allExist} - If every element exists.
    * @returns {ExpectAllExistResult.elements} - ExpectExistenceElement[].
    */
   async expectAllExist(

--- a/packages/askui-nodejs/src/main.ts
+++ b/packages/askui-nodejs/src/main.ts
@@ -1,5 +1,11 @@
 export { UiController } from './lib';
-export { UiControlClient, RelationsForConvenienceMethods } from './execution';
+export {
+  UiControlClient,
+  RelationsForConvenienceMethods,
+  ExpectExistenceAllowedElementClasses,
+  ExpectExistenceInputParameter,
+  ExpectExistenceReturnValue,
+} from './execution';
 export {
   Instruction,
   Reporter,

--- a/packages/askui-nodejs/src/main.ts
+++ b/packages/askui-nodejs/src/main.ts
@@ -1,10 +1,5 @@
 export { UiController } from './lib';
-export {
-  UiControlClient,
-  RelationsForConvenienceMethods,
-  ExpectExistenceInputParameter,
-  ExpectExistenceReturnValue,
-} from './execution';
+export * from './execution';
 export {
   Instruction,
   Reporter,

--- a/packages/askui-nodejs/src/main.ts
+++ b/packages/askui-nodejs/src/main.ts
@@ -2,7 +2,6 @@ export { UiController } from './lib';
 export {
   UiControlClient,
   RelationsForConvenienceMethods,
-  ExpectExistenceAllowedElementClasses,
   ExpectExistenceInputParameter,
   ExpectExistenceReturnValue,
 } from './execution';


### PR DESCRIPTION
Adds the convenience method

```async expectExistence(
    params: ExpectExistenceInputParameter[],
  ): Promise<ExpectExistenceReturnValue>
  ```
  
  It takes an array of elements in the form of `ExpectExistenceInputParameter`:
  
  ```
  export type ExpectExistenceInputParameter = {
  type: ExpectExistenceAllowedElementClasses;
  label: string;
  matching?: 'similar' | 'exact' | 'regex';
  relation?: {
    type: RelationsForConvenienceMethods;
    text?: string;
  };
  exists?: boolean;
};
```

and returns `ExpectExistenceReturnValue` with a property `everythingExists` and the the Input-Parameter with `exists` that shows if the element was found:

```
export type ExpectExistenceReturnValue = {
  everythingExists: boolean;
  elements: ExpectExistenceInputParameter[];
};
```

Comprehensive tests can be found in our QA-Repository: https://github.com/askui/askui-qa-system-test/pull/2