### PR TITLE
fix: clear dangling timeout ref

### DIFF
--- a/packages/askui-nodejs/src/execution/ui-controller-client.ts
+++ b/packages/askui-nodejs/src/execution/ui-controller-client.ts
@@ -36,7 +36,7 @@ export class UiControllerClient {
 
   connectionState = UiControllerClientConnectionState.NOT_CONNECTED;
 
-  private timeout?: NodeJS.Timeout;
+  private timeout?: NodeJS.Timeout | undefined;
 
   private currentReject: (reason?: unknown) => void = UiControllerClient.EMPTY_REJECT;
 
@@ -55,6 +55,7 @@ export class UiControllerClient {
   private onMessage(data: WebSocket.Data) {
     logger.debug('onMessage');
     clearTimeout(this.timeout as NodeJS.Timeout);
+    this.timeout = undefined;
     const response: RunnerProtocolResponse = JSON.parse(data.toString());
     if (response.data.error) {
       logger.error(response.data.error);


### PR DESCRIPTION
# Context

Contains fix where clearTimeout does not removes the reference but tells the event loop to not execute this and the garbase collector collects it.

Setting it explicitly to undefined helps in execution of the next step where we have the check for `if (this.timeout) {`.