### PR TITLE
Fix logo svg url typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![askui logo](./img/askui-logo-white.svg.svg#gh-dark-mode-only)
+![askui logo](./img/askui-logo-white.svg#gh-dark-mode-only)
 ![askui logo](./img/askui-logo.svg#gh-light-mode-only)
 
 *Reliable, automated end-to-end-automation that only depends on what is shown on your screen instead of the technology or platform you are running on*


### PR DESCRIPTION
The dark mode logo .svg URL had ".svg.svg" so wasn't rendering