### PR TITLE
fix(http-client): enable got retry for transient server errors on POS…

### DIFF
--- a/packages/askui-nodejs/src/utils/http/http-client-got.ts
+++ b/packages/askui-nodejs/src/utils/http/http-client-got.ts
@@ -1,6 +1,7 @@
 import got, {
   ExtendOptions,
   Got,
+  HTTPError,
   OptionsOfJSONResponseBody,
   RequestError,
   TimeoutError,
@@ -57,6 +58,16 @@ export class HttpClientGot {
     this.askuiGot = got.extend(gotExtendOptions);
   }
 
+  /**
+   * Configures got with retry behavior for transient server errors.
+   *
+   * Got retries requests that fail with retryable status codes
+   * (500, 502, 503, 504, etc.) up to `limit` times using exponential backoff.
+   *
+   * POST requests are only retried if their URL is registered in `urlsToRetry`
+   * (see `shouldRetryOnError`), to avoid retrying non-idempotent calls
+   * to unknown endpoints.
+   */
   private buildGotExtendOptions(
     proxyAgents?: { http: http.Agent; https: https.Agent } | undefined,
   ): ExtendOptions {
@@ -142,6 +153,11 @@ export class HttpClientGot {
     return gotExtendOptions;
   }
 
+  /**
+   * Only retry POST requests if the URL is explicitly registered in `urlsToRetry`
+   * (populated by InferenceClient with inference endpoint URLs).
+   * Non-POST requests (GET, PUT, etc.) are always retried.
+   */
   private shouldRetryOnError(error: TimeoutError | RequestError): boolean {
     return (
       error.request?.options.method !== 'POST'
@@ -187,22 +203,39 @@ export class HttpClientGot {
     url: string,
     data: Record<string | number | symbol, unknown>,
   ): Promise<{ headers: http.IncomingHttpHeaders; body: T }> {
+    // Note: We intentionally do NOT set `throwHttpErrors: false` here.
+    // Got must throw on non-2xx responses so that its built-in retry mechanism
+    // (configured in buildGotExtendOptions) can kick in for transient server errors
+    // (500, 502, 503, 504). After all retries are exhausted, got throws an HTTPError
+    // which we catch below and convert into our custom error hierarchy.
     const options = this.injectHeadersAndCookies(url, {
       json: data,
       responseType: 'json',
-      throwHttpErrors: false,
     });
-    const { body, statusCode, headers } = await this.askuiGot.post<T>(
-      url,
-      options,
-    );
-    if (headers['deprecation'] !== undefined) {
-      logger.warn(headers['deprecation']);
+    try {
+      const { body, statusCode, headers } = await this.askuiGot.post<T>(
+        url,
+        options,
+      );
+      if (headers['deprecation'] !== undefined) {
+        logger.warn(headers['deprecation']);
+      }
+      if (statusCode !== 200) {
+        throw httpClientErrorHandler(statusCode, JSON.stringify(body));
+      }
+      return { body, headers };
+    } catch (error) {
+      // After got exhausts all retries, it throws HTTPError.
+      // Convert it to our custom error types (ServerHttpClientError,
+      // AuthenticationHttpClientError, etc.) for consistent error handling.
+      if (error instanceof HTTPError) {
+        throw httpClientErrorHandler(
+          error.response.statusCode,
+          error.response.body as string,
+        );
+      }
+      throw error;
     }
-    if (statusCode !== 200) {
-      throw httpClientErrorHandler(statusCode, JSON.stringify(body));
-    }
-    return { body, headers };
   }
 
   async get<T>(

--- a/packages/askui-nodejs/src/utils/http/http-client-got.ts
+++ b/packages/askui-nodejs/src/utils/http/http-client-got.ts
@@ -213,15 +213,12 @@ export class HttpClientGot {
       responseType: 'json',
     });
     try {
-      const { body, statusCode, headers } = await this.askuiGot.post<T>(
+      const { body, headers } = await this.askuiGot.post<T>(
         url,
         options,
       );
       if (headers['deprecation'] !== undefined) {
         logger.warn(headers['deprecation']);
-      }
-      if (statusCode !== 200) {
-        throw httpClientErrorHandler(statusCode, JSON.stringify(body));
       }
       return { body, headers };
     } catch (error) {

--- a/packages/askui-nodejs/src/utils/http/http-client-got.ts
+++ b/packages/askui-nodejs/src/utils/http/http-client-got.ts
@@ -12,6 +12,7 @@ import https from 'https';
 import { logger } from '../../lib';
 import { Credentials } from './credentials';
 import { httpClientErrorHandler } from './custom-errors';
+import { UnkownHttpClientError } from './custom-errors/unkown-http-client-error';
 
 function buildRetryLog(
   requestUrl: string | undefined,
@@ -231,7 +232,9 @@ export class HttpClientGot {
           error.response.body as string,
         );
       }
-      throw error;
+      throw new UnkownHttpClientError(
+        error instanceof Error ? error.message : String(error),
+      );
     }
   }
 


### PR DESCRIPTION
…T requests (#SOLENG-333)

Remove `throwHttpErrors: false` from the POST method so that got's built-in retry mechanism (5 retries, exponential backoff) can trigger for transient server errors (500, 502, 503, 504). Previously, got silently returned error responses without retrying because it did not see them as errors. After retries are exhausted, HTTPError is caught and converted to our custom error hierarchy for consistent handling.

This fixes intermittent CUDNN_STATUS_INTERNAL_ERROR (500) responses from the Azure GPU backend that cannot be fixed server-side.

Refs: SOLENG-333