### PR TITLE
chore(security): resolve npm audit vulnerabilities in askui-nodejs

### DIFF
--- a/packages/askui-nodejs/package-lock.json
+++ b/packages/askui-nodejs/package-lock.json
@@ -64,7 +64,7 @@
                 "lint-staged": "15.5.2",
                 "proxy": "^1.0.2",
                 "proxy-agent": "^6.3.0",
-                "release-it": "20.0.0",
+                "release-it": "^20.0.1",
                 "shx": "0.3.4",
                 "ts-jest": "29.2.5",
                 "typescript": "5.6.2"
@@ -1467,22 +1467,22 @@
             }
         },
         "node_modules/@inquirer/prompts": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.2.tgz",
-            "integrity": "sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w==",
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.2.tgz",
+            "integrity": "sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/checkbox": "^5.1.2",
-                "@inquirer/confirm": "^6.0.10",
-                "@inquirer/editor": "^5.0.10",
-                "@inquirer/expand": "^5.0.10",
-                "@inquirer/input": "^5.0.10",
-                "@inquirer/number": "^4.0.10",
-                "@inquirer/password": "^5.0.10",
-                "@inquirer/rawlist": "^5.2.6",
-                "@inquirer/search": "^4.1.6",
-                "@inquirer/select": "^5.1.2"
+                "@inquirer/checkbox": "^5.1.4",
+                "@inquirer/confirm": "^6.0.12",
+                "@inquirer/editor": "^5.1.1",
+                "@inquirer/expand": "^5.0.13",
+                "@inquirer/input": "^5.0.12",
+                "@inquirer/number": "^4.0.12",
+                "@inquirer/password": "^5.0.12",
+                "@inquirer/rawlist": "^5.2.8",
+                "@inquirer/search": "^4.1.8",
+                "@inquirer/select": "^5.1.4"
             },
             "engines": {
                 "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -2123,16 +2123,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/@nodeutils/defaults-deep": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@nodeutils/defaults-deep/-/defaults-deep-1.1.0.tgz",
-            "integrity": "sha512-gG44cwQovaOFdSR02jR9IhVRpnDP64VN6JdjYJTfNz4J4fWn7TQnmrf22nSjRqlwlxPcW8PL/L3KbJg3tdwvpg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lodash": "^4.15.0"
-            }
-        },
         "node_modules/@npmcli/agent": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
@@ -2558,7 +2548,8 @@
             "version": "0.23.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
             "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -3088,12 +3079,10 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 14"
             }
@@ -3474,6 +3463,7 @@
             "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
             "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "tslib": "^2.0.1"
             },
@@ -3675,9 +3665,9 @@
             "dev": true
         },
         "node_modules/basic-ftp": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-            "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+            "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4760,6 +4750,7 @@
             "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
             "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 14"
             }
@@ -5034,6 +5025,7 @@
             "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
             "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ast-types": "^0.13.4",
                 "escodegen": "^2.1.0",
@@ -5541,6 +5533,7 @@
             "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
             "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "esprima": "^4.0.1",
                 "estraverse": "^5.2.0",
@@ -5562,6 +5555,7 @@
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
             }
@@ -6153,9 +6147,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -6167,6 +6161,7 @@
                     "url": "https://opencollective.com/fastify"
                 }
             ],
+            "license": "BSD-3-Clause",
             "optional": true
         },
         "node_modules/fast-wrap-ansi": {
@@ -6600,15 +6595,15 @@
             }
         },
         "node_modules/get-uri": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
-            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+            "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "basic-ftp": "^5.0.2",
                 "data-uri-to-buffer": "^6.0.2",
-                "debug": "^4.3.4",
-                "fs-extra": "^11.2.0"
+                "debug": "^4.3.4"
             },
             "engines": {
                 "node": ">= 14"
@@ -7020,11 +7015,12 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
             "dependencies": {
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "4"
             },
             "engines": {
@@ -7205,14 +7201,11 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
             "dev": true,
-            "dependencies": {
-                "jsbn": "1.1.0",
-                "sprintf-js": "^1.1.3"
-            },
+            "license": "MIT",
             "engines": {
                 "node": ">= 12"
             }
@@ -8385,12 +8378,6 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
-        },
-        "node_modules/jsbn": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-            "dev": true
         },
         "node_modules/jsdom": {
             "version": "25.0.1",
@@ -10001,10 +9988,11 @@
             "license": "MIT"
         },
         "node_modules/netmask": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+            "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
             }
@@ -10552,19 +10540,20 @@
             }
         },
         "node_modules/pac-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+            "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@tootallnate/quickjs-emscripten": "^0.23.0",
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
                 "get-uri": "^6.0.1",
                 "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.5",
+                "https-proxy-agent": "^7.0.6",
                 "pac-resolver": "^7.0.1",
-                "socks-proxy-agent": "^8.0.4"
+                "socks-proxy-agent": "^8.0.5"
             },
             "engines": {
                 "node": ">= 14"
@@ -10575,6 +10564,7 @@
             "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
             "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "degenerator": "^5.0.0",
                 "netmask": "^2.0.2"
@@ -11180,19 +11170,20 @@
             }
         },
         "node_modules/proxy-agent": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+            "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
                 "http-proxy-agent": "^7.0.1",
-                "https-proxy-agent": "^7.0.3",
+                "https-proxy-agent": "^7.0.6",
                 "lru-cache": "^7.14.1",
-                "pac-proxy-agent": "^7.0.1",
+                "pac-proxy-agent": "^7.1.0",
                 "proxy-from-env": "^1.1.0",
-                "socks-proxy-agent": "^8.0.2"
+                "socks-proxy-agent": "^8.0.5"
             },
             "engines": {
                 "node": ">= 14"
@@ -11449,9 +11440,9 @@
             }
         },
         "node_modules/release-it": {
-            "version": "20.0.0",
-            "resolved": "https://registry.npmjs.org/release-it/-/release-it-20.0.0.tgz",
-            "integrity": "sha512-KLCgEJH+t/MnJieOzjcroFcTSFY8dw44HT9joMm6+R5hPa+h2qPrDhHHZ5eN6m1yx8KK+q7KNdM7AfJYfAVFvQ==",
+            "version": "20.0.1",
+            "resolved": "https://registry.npmjs.org/release-it/-/release-it-20.0.1.tgz",
+            "integrity": "sha512-3ob1P1aV+3+ZOoR7qgobfYyMlQbpitzOK09iKTtQ145vFi4rWxlRTgHwtVl8kokCvqiF/cJPxRlfcmZmF5aDJA==",
             "dev": true,
             "funding": [
                 {
@@ -11465,13 +11456,13 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@inquirer/prompts": "8.3.2",
-                "@nodeutils/defaults-deep": "1.1.0",
+                "@inquirer/prompts": "8.4.2",
                 "@octokit/rest": "22.0.1",
                 "@phun-ky/typeof": "2.0.3",
                 "async-retry": "1.3.3",
                 "c12": "3.3.3",
                 "ci-info": "^4.4.0",
+                "defu": "^6.1.7",
                 "eta": "4.5.1",
                 "git-url-parse": "16.1.0",
                 "issue-parser": "7.0.1",
@@ -12135,9 +12126,10 @@
             }
         },
         "node_modules/rxjs": {
-            "version": "7.8.1",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -12503,12 +12495,13 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+            "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "ip-address": "^9.0.5",
+                "ip-address": "^10.1.1",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
@@ -12517,12 +12510,13 @@
             }
         },
         "node_modules/socks-proxy-agent": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
-            "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+            "version": "8.0.5",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "agent-base": "^7.1.1",
+                "agent-base": "^7.1.2",
                 "debug": "^4.3.4",
                 "socks": "^2.8.3"
             },
@@ -12596,12 +12590,6 @@
             "engines": {
                 "node": ">= 10.x"
             }
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "dev": true
         },
         "node_modules/ssri": {
             "version": "12.0.0",

--- a/packages/askui-nodejs/package-lock.json
+++ b/packages/askui-nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "askui",
-    "version": "0.31.0",
+    "version": "0.32.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "askui",
-            "version": "0.31.0",
+            "version": "0.32.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
@@ -37,8 +37,8 @@
             },
             "devDependencies": {
                 "@cyclonedx/cyclonedx-npm": "^4.1.2",
-                "@release-it/bumper": "6.0.1",
-                "@release-it/conventional-changelog": "8.0.2",
+                "@release-it/bumper": "7.0.5",
+                "@release-it/conventional-changelog": "11.0.0",
                 "@types/fs-extra": "11.0.4",
                 "@types/inquirer": "9.0.7",
                 "@types/is-ci": "^3.0.4",
@@ -61,10 +61,10 @@
                 "hpagent": "^1.2.0",
                 "jest": "29.7.0",
                 "jest-extended": "^4.0.2",
-                "lint-staged": "15.2.10",
+                "lint-staged": "15.5.2",
                 "proxy": "^1.0.2",
                 "proxy-agent": "^6.3.0",
-                "release-it": "17.6.0",
+                "release-it": "20.0.0",
                 "shx": "0.3.4",
                 "ts-jest": "29.2.5",
                 "typescript": "5.6.2"
@@ -602,6 +602,33 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
+        "node_modules/@conventional-changelog/git-client": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+            "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@simple-libs/child-process-utils": "^1.0.0",
+                "@simple-libs/stream-utils": "^1.2.0",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "conventional-commits-filter": "^5.0.0",
+                "conventional-commits-parser": "^6.4.0"
+            },
+            "peerDependenciesMeta": {
+                "conventional-commits-filter": {
+                    "optional": true
+                },
+                "conventional-commits-parser": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@cyclonedx/cyclonedx-npm": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-npm/-/cyclonedx-npm-4.1.2.tgz",
@@ -806,20 +833,12 @@
             "deprecated": "Use @eslint/object-schema instead",
             "dev": true
         },
-        "node_modules/@hutson/parse-repository-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-5.0.0.tgz",
-            "integrity": "sha512-e5+YUKENATs1JgYHMzTr2MW/NDcXGfYFAuOQU8gJgF/kEh4EqKgfGrfLI67bMD4tbhZVlkigz/9YYwWcbOFthg==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
         "node_modules/@iarna/toml": {
-            "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-            "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
-            "dev": true
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-3.0.0.tgz",
+            "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/@img/sharp-darwin-arm64": {
             "version": "0.33.5",
@@ -1163,13 +1182,405 @@
                 "url": "https://opencollective.com/libvips"
             }
         },
-        "node_modules/@inquirer/figures": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.7.tgz",
-            "integrity": "sha512-m+Trk77mp54Zma6xLkLuY+mvanPxlE4A7yNKs2HBiyZ4UkVs28Mv5c/pgWrHeInx+USHeX/WEPzjrWrcJiQgjw==",
+        "node_modules/@inquirer/ansi": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+            "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            }
+        },
+        "node_modules/@inquirer/checkbox": {
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.4.tgz",
+            "integrity": "sha512-w6KF8ZYRvqHhROkOTHXYC3qIV/KYEu5o12oLqQySvch61vrYtRxNSHTONSdJqWiFJPlCUQAHT5OgOIyuTr+MHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/ansi": "^2.0.5",
+                "@inquirer/core": "^11.1.9",
+                "@inquirer/figures": "^2.0.5",
+                "@inquirer/type": "^4.0.5"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/confirm": {
+            "version": "6.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.12.tgz",
+            "integrity": "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^11.1.9",
+                "@inquirer/type": "^4.0.5"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/core": {
+            "version": "11.1.9",
+            "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz",
+            "integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/ansi": "^2.0.5",
+                "@inquirer/figures": "^2.0.5",
+                "@inquirer/type": "^4.0.5",
+                "cli-width": "^4.1.0",
+                "fast-wrap-ansi": "^0.2.0",
+                "mute-stream": "^3.0.0",
+                "signal-exit": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/cli-width": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+            "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/mute-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+            "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/@inquirer/core/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@inquirer/editor": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.1.1.tgz",
+            "integrity": "sha512-6y11LgmNpmn5D2aB5FgnCfBUBK8ZstwLCalyJmORcJZ/WrhOjm16mu6eSqIx8DnErxDqSLr+Jkp+GP8/Nwd5tA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^11.1.9",
+                "@inquirer/external-editor": "^3.0.0",
+                "@inquirer/type": "^4.0.5"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/expand": {
+            "version": "5.0.13",
+            "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.13.tgz",
+            "integrity": "sha512-dF2zvrFo9LshkcB23/O1il13kBkBltWIXzut1evfbuBLXMiGIuC45c+ZQ0uukjCDsvI8OWqun4FRYMnzFCQa3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^11.1.9",
+                "@inquirer/type": "^4.0.5"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/external-editor": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.0.tgz",
+            "integrity": "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chardet": "^2.1.1",
+                "iconv-lite": "^0.7.2"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/external-editor/node_modules/chardet": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+            "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/@inquirer/figures": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+            "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            }
+        },
+        "node_modules/@inquirer/input": {
+            "version": "5.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.12.tgz",
+            "integrity": "sha512-uiMFBl4LqFzJClh80Q3f9hbOFJ6kgkDWI4LjAeBuyO6EanVVMF69AgOvpi1qdqjDSjDN6578B6nky9ceEpI+1Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^11.1.9",
+                "@inquirer/type": "^4.0.5"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/number": {
+            "version": "4.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.12.tgz",
+            "integrity": "sha512-/vrwhEf7Xsuh+YlHF4IjSy3g1cyrQuPaSiHIxCEbLu8qnfvrcvJyCkoktOOF+xV9gSb77/G0n3h04RbMDW2sIg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^11.1.9",
+                "@inquirer/type": "^4.0.5"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/password": {
+            "version": "5.0.12",
+            "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.12.tgz",
+            "integrity": "sha512-CBh7YHju623lxJRcAOo498ZUwIuMy63bqW/vVq0tQAZVv+lkWlHkP9ealYE1utWSisEShY5VMdzIXRmyEODzcQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/ansi": "^2.0.5",
+                "@inquirer/core": "^11.1.9",
+                "@inquirer/type": "^4.0.5"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/prompts": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.2.tgz",
+            "integrity": "sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/checkbox": "^5.1.2",
+                "@inquirer/confirm": "^6.0.10",
+                "@inquirer/editor": "^5.0.10",
+                "@inquirer/expand": "^5.0.10",
+                "@inquirer/input": "^5.0.10",
+                "@inquirer/number": "^4.0.10",
+                "@inquirer/password": "^5.0.10",
+                "@inquirer/rawlist": "^5.2.6",
+                "@inquirer/search": "^4.1.6",
+                "@inquirer/select": "^5.1.2"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/rawlist": {
+            "version": "5.2.8",
+            "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.8.tgz",
+            "integrity": "sha512-Su7FQvp5buZmCymN3PPoYv31ZQQX4ve2j02k7piGgKAWgE+AQRB5YoYVveGXcl3TZ9ldgRMSxj56YfDFmmaqLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^11.1.9",
+                "@inquirer/type": "^4.0.5"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/search": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.8.tgz",
+            "integrity": "sha512-fGiHKGD6DyPIYUWxoXnQTeXeyYqSOUrasDMABBmMHUalH/LxkuzY0xVRtimXAt1sUeeyYkVuKQx1bebMuN11Kw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/core": "^11.1.9",
+                "@inquirer/figures": "^2.0.5",
+                "@inquirer/type": "^4.0.5"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/select": {
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.4.tgz",
+            "integrity": "sha512-2kWcGKPMLAXAWRp1AH1SLsQmX+j0QjeljyXMUji9WMZC8nRDO0b7qquIGr6143E7KMLt3VAIGNXzwa/6PXQs4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@inquirer/ansi": "^2.0.5",
+                "@inquirer/core": "^11.1.9",
+                "@inquirer/figures": "^2.0.5",
+                "@inquirer/type": "^4.0.5"
+            },
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@inquirer/type": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+            "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@isaacs/cliui": {
@@ -1712,6 +2123,16 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@nodeutils/defaults-deep": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@nodeutils/defaults-deep/-/defaults-deep-1.1.0.tgz",
+            "integrity": "sha512-gG44cwQovaOFdSR02jR9IhVRpnDP64VN6JdjYJTfNz4J4fWn7TQnmrf22nSjRqlwlxPcW8PL/L3KbJg3tdwvpg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lodash": "^4.15.0"
+            }
+        },
         "node_modules/@npmcli/agent": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
@@ -1743,161 +2164,170 @@
             }
         },
         "node_modules/@octokit/auth-token": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+            "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
-            "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+            "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@octokit/auth-token": "^4.0.0",
-                "@octokit/graphql": "^7.1.0",
-                "@octokit/request": "^8.3.1",
-                "@octokit/request-error": "^5.1.0",
-                "@octokit/types": "^13.0.0",
-                "before-after-hook": "^2.2.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/auth-token": "^6.0.0",
+                "@octokit/graphql": "^9.0.3",
+                "@octokit/request": "^10.0.6",
+                "@octokit/request-error": "^7.0.2",
+                "@octokit/types": "^16.0.0",
+                "before-after-hook": "^4.0.0",
+                "universal-user-agent": "^7.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "9.0.6",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
-            "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+            "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^13.1.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/types": "^16.0.0",
+                "universal-user-agent": "^7.0.2"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
-            "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+            "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@octokit/request": "^8.3.0",
-                "@octokit/types": "^13.0.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/request": "^10.0.6",
+                "@octokit/types": "^16.0.0",
+                "universal-user-agent": "^7.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
         "node_modules/@octokit/openapi-types": {
-            "version": "22.2.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-            "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-            "dev": true
+            "version": "27.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+            "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "11.3.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.1.tgz",
-            "integrity": "sha512-ryqobs26cLtM1kQxqeZui4v8FeznirUsksiA+RYemMPJ7Micju0WSkv50dBksTuZks9O5cg4wp+t8fZ/cLY56g==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+            "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^13.5.0"
+                "@octokit/types": "^16.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             },
             "peerDependencies": {
-                "@octokit/core": "5"
+                "@octokit/core": ">=6"
             }
         },
         "node_modules/@octokit/plugin-request-log": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
-            "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+            "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             },
             "peerDependencies": {
-                "@octokit/core": "5"
+                "@octokit/core": ">=6"
             }
         },
         "node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "13.2.2",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.2.tgz",
-            "integrity": "sha512-EI7kXWidkt3Xlok5uN43suK99VWqc8OaIMktY9d9+RNKl69juoTyxmLoWPIZgJYzi41qj/9zU7G/ljnNOJ5AFA==",
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+            "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^13.5.0"
+                "@octokit/types": "^16.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             },
             "peerDependencies": {
-                "@octokit/core": "^5"
+                "@octokit/core": ">=6"
             }
         },
         "node_modules/@octokit/request": {
-            "version": "8.4.1",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
-            "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+            "version": "10.0.8",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+            "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@octokit/endpoint": "^9.0.6",
-                "@octokit/request-error": "^5.1.1",
-                "@octokit/types": "^13.1.0",
-                "universal-user-agent": "^6.0.0"
+                "@octokit/endpoint": "^11.0.3",
+                "@octokit/request-error": "^7.0.2",
+                "@octokit/types": "^16.0.0",
+                "fast-content-type-parse": "^3.0.0",
+                "json-with-bigint": "^3.5.3",
+                "universal-user-agent": "^7.0.2"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
         "node_modules/@octokit/request-error": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
-            "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+            "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^13.1.0",
-                "deprecation": "^2.0.0",
-                "once": "^1.4.0"
+                "@octokit/types": "^16.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
         "node_modules/@octokit/rest": {
-            "version": "20.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.1.tgz",
-            "integrity": "sha512-MB4AYDsM5jhIHro/dq4ix1iWTLGToIGk6cWF5L6vanFaMble5jTX/UBQyiv05HsWnwUtY8JrfHy2LWfKwihqMw==",
+            "version": "22.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+            "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@octokit/core": "^5.0.2",
-                "@octokit/plugin-paginate-rest": "11.3.1",
-                "@octokit/plugin-request-log": "^4.0.0",
-                "@octokit/plugin-rest-endpoint-methods": "13.2.2"
+                "@octokit/core": "^7.0.6",
+                "@octokit/plugin-paginate-rest": "^14.0.0",
+                "@octokit/plugin-request-log": "^6.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
         "node_modules/@octokit/types": {
-            "version": "13.6.1",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.1.tgz",
-            "integrity": "sha512-PHZE9Z+kWXb23Ndik8MKPirBPziOc0D2/3KH1P+6jK5nGWe96kadZuE4jev2/Jq7FvIfTlT2Ltg8Fv2x1v0a5g==",
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+            "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@octokit/openapi-types": "^22.2.0"
+                "@octokit/openapi-types": "^27.0.0"
             }
         },
         "node_modules/@oozcitak/dom": {
@@ -1948,6 +2378,20 @@
                 "node": ">=20.0"
             }
         },
+        "node_modules/@phun-ky/typeof": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@phun-ky/typeof/-/typeof-2.0.3.tgz",
+            "integrity": "sha512-oeQJs1aa8Ghke8JIK9yuq/+KjMiaYeDZ38jx7MhkXncXlUKjqQ3wEm2X3qCKyjo+ZZofZj+WsEEiqkTtRuE2xQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.9.0 || >=22.0.0",
+                "npm": ">=10.8.2"
+            },
+            "funding": {
+                "url": "https://github.com/phun-ky/typeof?sponsor=1"
+            }
+        },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1958,85 +2402,49 @@
                 "node": ">=14"
             }
         },
-        "node_modules/@pnpm/config.env-replace": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
-            "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.22.0"
-            }
-        },
-        "node_modules/@pnpm/network.ca-file": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
-            "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "4.2.10"
-            },
-            "engines": {
-                "node": ">=12.22.0"
-            }
-        },
-        "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-            "dev": true
-        },
-        "node_modules/@pnpm/npm-conf": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.3.1.tgz",
-            "integrity": "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==",
-            "dev": true,
-            "dependencies": {
-                "@pnpm/config.env-replace": "^1.1.0",
-                "@pnpm/network.ca-file": "^1.0.1",
-                "config-chain": "^1.1.11"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/@release-it/bumper": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/@release-it/bumper/-/bumper-6.0.1.tgz",
-            "integrity": "sha512-yeQsbGNMzzN0c/5JV1awXP6UHX/kJamXCKR6/daS0YQfj98SZXAcLn3JEq+qfK/Jq/cnATnlz5r6UY0cfBkm1A==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/@release-it/bumper/-/bumper-7.0.5.tgz",
+            "integrity": "sha512-HCFMqDHreLYg4jjTWL//pW1GzZZMn3p7HDbwS2y7y5m0L6p8hEaOEixC3tEzwyVV7VP1VGjqxMvxfa360q8+Tg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@iarna/toml": "^2.2.5",
+                "@iarna/toml": "^3.0.0",
+                "cheerio": "^1.0.0",
                 "detect-indent": "7.0.1",
-                "fast-glob": "^3.3.2",
-                "ini": "^4.1.1",
+                "fast-glob": "^3.3.3",
+                "ini": "^5.0.0",
                 "js-yaml": "^4.1.0",
                 "lodash-es": "^4.17.21",
-                "semver": "^7.3.7"
+                "semver": "^7.7.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": "^20.9.0 || >=22.0.0"
             },
             "peerDependencies": {
-                "release-it": "^17.0.0"
+                "release-it": ">=18.0.0 || >=19.0.0"
             }
         },
         "node_modules/@release-it/conventional-changelog": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@release-it/conventional-changelog/-/conventional-changelog-8.0.2.tgz",
-            "integrity": "sha512-WpnWWRr7O0JeLoiejLrPEWnnwFhCscBn1wBTAXeitiz2/Ifaol0s+t8otf/HYq/OiQOri2iH8d0CnVb72tBdIQ==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/@release-it/conventional-changelog/-/conventional-changelog-11.0.0.tgz",
+            "integrity": "sha512-3/WyzObY+y+EejBt+J2vcojFPLUiGu14liRiaPWc0bNVluhRIsADeJ785Iq5ynnhdd1zcjMNh5lBmM/J6/KXig==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
+                "@conventional-changelog/git-client": "^2.7.0",
                 "concat-stream": "^2.0.0",
-                "conventional-changelog": "^5.1.0",
-                "conventional-recommended-bump": "^9.0.0",
-                "git-semver-tags": "^8.0.0",
-                "semver": "^7.6.3"
+                "conventional-changelog": "^7.2.0",
+                "conventional-changelog-angular": "^8.3.1",
+                "conventional-changelog-conventionalcommits": "^9.3.1",
+                "conventional-recommended-bump": "^11.2.0",
+                "semver": "^7.7.4"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || ^22.0.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
             },
             "peerDependencies": {
-                "release-it": "^17.0.0"
+                "release-it": "^18.0.0 || ^19.0.0 || ^20.0.0"
             }
         },
         "node_modules/@samverschueren/stream-to-observable": {
@@ -2074,6 +2482,19 @@
                 "url": "https://ko-fi.com/dangreen"
             }
         },
+        "node_modules/@simple-libs/hosted-git-info": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@simple-libs/hosted-git-info/-/hosted-git-info-1.0.2.tgz",
+            "integrity": "sha512-aAmGQdMH+ZinytKuA2832u0ATeOFNYNk4meBEXtB5xaPotUgggYNhq5tYU/v17wEbmTW5P9iHNqNrFyrhnqBAg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/dangreen"
+            }
+        },
         "node_modules/@simple-libs/stream-utils": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
@@ -2102,18 +2523,6 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
-            }
-        },
-        "node_modules/@sindresorhus/merge-streams": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-            "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@sinonjs/commons": {
@@ -2366,13 +2775,21 @@
             "version": "2.4.4",
             "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
             "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/nunjucks": {
             "version": "3.2.6",
             "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.6.tgz",
             "integrity": "sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==",
             "dev": true
+        },
+        "node_modules/@types/parse-path": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
+            "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/responselike": {
             "version": "1.0.3",
@@ -2670,12 +3087,6 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
-        "node_modules/add-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-            "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
-            "dev": true
-        },
         "node_modules/agent-base": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
@@ -2775,15 +3186,6 @@
             "dev": true,
             "optional": true
         },
-        "node_modules/ansi-align": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-            "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-            "dev": true,
-            "dependencies": {
-                "string-width": "^4.1.0"
-            }
-        },
         "node_modules/ansi-escapes": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2843,7 +3245,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
             "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -2982,7 +3384,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
             "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/array-includes": {
             "version": "3.1.8",
@@ -3272,9 +3675,9 @@
             "dev": true
         },
         "node_modules/basic-ftp": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-            "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+            "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3282,10 +3685,25 @@
             }
         },
         "node_modules/before-after-hook": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-            "dev": true
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+            "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/binary-extensions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/bindings": {
             "version": "1.5.0",
@@ -3307,142 +3725,12 @@
                 "readable-stream": "^3.4.0"
             }
         },
-        "node_modules/boxen": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.1.1.tgz",
-            "integrity": "sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==",
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
             "dev": true,
-            "dependencies": {
-                "ansi-align": "^3.0.1",
-                "camelcase": "^7.0.1",
-                "chalk": "^5.2.0",
-                "cli-boxes": "^3.0.0",
-                "string-width": "^5.1.2",
-                "type-fest": "^2.13.0",
-                "widest-line": "^4.0.1",
-                "wrap-ansi": "^8.1.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/boxen/node_modules/ansi-regex": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/boxen/node_modules/ansi-styles": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/boxen/node_modules/camelcase": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
-            "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
-            "dev": true,
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/boxen/node_modules/chalk": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-            "dev": true,
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/boxen/node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-            "dev": true
-        },
-        "node_modules/boxen/node_modules/string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-            "dev": true,
-            "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/boxen/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "node_modules/boxen/node_modules/type-fest": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/boxen/node_modules/wrap-ansi": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
+            "license": "ISC"
         },
         "node_modules/brace-expansion": {
             "version": "1.1.13",
@@ -3459,7 +3747,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
@@ -3554,6 +3842,7 @@
             "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
             "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "run-applescript": "^7.0.0"
             },
@@ -3562,6 +3851,65 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/c12": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
+            "integrity": "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chokidar": "^5.0.0",
+                "confbox": "^0.2.2",
+                "defu": "^6.1.4",
+                "dotenv": "^17.2.3",
+                "exsolve": "^1.0.8",
+                "giget": "^2.0.0",
+                "jiti": "^2.6.1",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "perfect-debounce": "^2.0.0",
+                "pkg-types": "^2.3.0",
+                "rc9": "^2.1.2"
+            },
+            "peerDependencies": {
+                "magicast": "*"
+            },
+            "peerDependenciesMeta": {
+                "magicast": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/c12/node_modules/chokidar": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/c12/node_modules/readdirp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/cacache": {
@@ -3788,6 +4136,90 @@
             "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
             "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
         },
+        "node_modules/cheerio": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+            "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cheerio-select": "^2.1.0",
+                "dom-serializer": "^2.0.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.2.2",
+                "encoding-sniffer": "^0.2.1",
+                "htmlparser2": "^10.1.0",
+                "parse5": "^7.3.0",
+                "parse5-htmlparser2-tree-adapter": "^7.1.0",
+                "parse5-parser-stream": "^7.1.2",
+                "undici": "^7.19.0",
+                "whatwg-mimetype": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=20.18.1"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+            }
+        },
+        "node_modules/cheerio-select": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+            "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-select": "^5.1.0",
+                "css-what": "^6.1.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/chokidar/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "license": "ISC",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/chownr": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -3812,6 +4244,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/citty": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+            "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "consola": "^3.2.3"
+            }
+        },
         "node_modules/cjs-module-lexer": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
@@ -3824,18 +4266,6 @@
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/cli-boxes": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-            "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cli-cursor": {
@@ -4048,6 +4478,7 @@
             "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
             "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "array-ify": "^1.0.0",
                 "dot-prop": "^5.1.0"
@@ -4074,67 +4505,12 @@
                 "typedarray": "^0.0.6"
             }
         },
-        "node_modules/config-chain": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
-            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+        "node_modules/confbox": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+            "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
             "dev": true,
-            "dependencies": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
-            }
-        },
-        "node_modules/config-chain/node_modules/ini": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "dev": true
-        },
-        "node_modules/configstore": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/configstore/-/configstore-6.0.0.tgz",
-            "integrity": "sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==",
-            "dev": true,
-            "dependencies": {
-                "dot-prop": "^6.0.1",
-                "graceful-fs": "^4.2.6",
-                "unique-string": "^3.0.0",
-                "write-file-atomic": "^3.0.3",
-                "xdg-basedir": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/yeoman/configstore?sponsor=1"
-            }
-        },
-        "node_modules/configstore/node_modules/dot-prop": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-            "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
-            "dev": true,
-            "dependencies": {
-                "is-obj": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/configstore/node_modules/write-file-atomic": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-            "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-            "dev": true,
-            "dependencies": {
-                "imurmurhash": "^0.1.4",
-                "is-typedarray": "^1.0.0",
-                "signal-exit": "^3.0.2",
-                "typedarray-to-buffer": "^3.1.5"
-            }
+            "license": "MIT"
         },
         "node_modules/confusing-browser-globals": {
             "version": "1.0.11",
@@ -4142,245 +4518,141 @@
             "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
             "dev": true
         },
-        "node_modules/conventional-changelog": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-5.1.0.tgz",
-            "integrity": "sha512-aWyE/P39wGYRPllcCEZDxTVEmhyLzTc9XA6z6rVfkuCD2UBnhV/sgSOKbQrEG5z9mEZJjnopjgQooTKxEg8mAg==",
+        "node_modules/consola": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+            "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.18.0 || >=16.10.0"
+            }
+        },
+        "node_modules/conventional-changelog": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-7.2.0.tgz",
+            "integrity": "sha512-BEdgG+vPl53EVlTTk9sZ96aagFp0AQ5pw/ggiQMy2SClLbTo1r0l+8dSg79gkLOO5DS1Lswuhp5fWn6RwE+ivg==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "conventional-changelog-angular": "^7.0.0",
-                "conventional-changelog-atom": "^4.0.0",
-                "conventional-changelog-codemirror": "^4.0.0",
-                "conventional-changelog-conventionalcommits": "^7.0.2",
-                "conventional-changelog-core": "^7.0.0",
-                "conventional-changelog-ember": "^4.0.0",
-                "conventional-changelog-eslint": "^5.0.0",
-                "conventional-changelog-express": "^4.0.0",
-                "conventional-changelog-jquery": "^5.0.0",
-                "conventional-changelog-jshint": "^4.0.0",
-                "conventional-changelog-preset-loader": "^4.1.0"
+                "@conventional-changelog/git-client": "^2.6.0",
+                "@simple-libs/hosted-git-info": "^1.0.2",
+                "@types/normalize-package-data": "^2.4.4",
+                "conventional-changelog-preset-loader": "^5.0.0",
+                "conventional-changelog-writer": "^8.3.0",
+                "conventional-commits-parser": "^6.3.0",
+                "fd-package-json": "^2.0.0",
+                "meow": "^13.0.0",
+                "normalize-package-data": "^7.0.0"
+            },
+            "bin": {
+                "conventional-changelog": "dist/cli/index.js"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             }
         },
         "node_modules/conventional-changelog-angular": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
-            "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+            "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "compare-func": "^2.0.0"
             },
             "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/conventional-changelog-atom": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-4.0.0.tgz",
-            "integrity": "sha512-q2YtiN7rnT1TGwPTwjjBSIPIzDJCRE+XAUahWxnh+buKK99Kks4WLMHoexw38GXx9OUxAsrp44f9qXe5VEMYhw==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/conventional-changelog-codemirror": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-4.0.0.tgz",
-            "integrity": "sha512-hQSojc/5imn1GJK3A75m9hEZZhc3urojA5gMpnar4JHmgLnuM3CUIARPpEk86glEKr3c54Po3WV/vCaO/U8g3Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
+                "node": ">=18"
             }
         },
         "node_modules/conventional-changelog-conventionalcommits": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-            "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+            "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "compare-func": "^2.0.0"
             },
             "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/conventional-changelog-core": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-7.0.0.tgz",
-            "integrity": "sha512-UYgaB1F/COt7VFjlYKVE/9tTzfU3VUq47r6iWf6lM5T7TlOxr0thI63ojQueRLIpVbrtHK4Ffw+yQGduw2Bhdg==",
-            "dev": true,
-            "dependencies": {
-                "@hutson/parse-repository-url": "^5.0.0",
-                "add-stream": "^1.0.0",
-                "conventional-changelog-writer": "^7.0.0",
-                "conventional-commits-parser": "^5.0.0",
-                "git-raw-commits": "^4.0.0",
-                "git-semver-tags": "^7.0.0",
-                "hosted-git-info": "^7.0.0",
-                "normalize-package-data": "^6.0.0",
-                "read-pkg": "^8.0.0",
-                "read-pkg-up": "^10.0.0"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/conventional-changelog-core/node_modules/git-semver-tags": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-7.0.1.tgz",
-            "integrity": "sha512-NY0ZHjJzyyNXHTDZmj+GG7PyuAKtMsyWSwh07CR2hOZFa+/yoTsXci/nF2obzL8UDhakFNkD9gNdt/Ed+cxh2Q==",
-            "dev": true,
-            "dependencies": {
-                "meow": "^12.0.1",
-                "semver": "^7.5.2"
-            },
-            "bin": {
-                "git-semver-tags": "cli.mjs"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/conventional-changelog-ember": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-4.0.0.tgz",
-            "integrity": "sha512-D0IMhwcJUg1Y8FSry6XAplEJcljkHVlvAZddhhsdbL1rbsqRsMfGx/PIkPYq0ru5aDgn+OxhQ5N5yR7P9mfsvA==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/conventional-changelog-eslint": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-5.0.0.tgz",
-            "integrity": "sha512-6JtLWqAQIeJLn/OzUlYmzd9fKeNSWmQVim9kql+v4GrZwLx807kAJl3IJVc3jTYfVKWLxhC3BGUxYiuVEcVjgA==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/conventional-changelog-express": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-4.0.0.tgz",
-            "integrity": "sha512-yWyy5c7raP9v7aTvPAWzqrztACNO9+FEI1FSYh7UP7YT1AkWgv5UspUeB5v3Ibv4/o60zj2o9GF2tqKQ99lIsw==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/conventional-changelog-jquery": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-5.0.0.tgz",
-            "integrity": "sha512-slLjlXLRNa/icMI3+uGLQbtrgEny3RgITeCxevJB+p05ExiTgHACP5p3XiMKzjBn80n+Rzr83XMYfRInEtCPPw==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/conventional-changelog-jshint": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-4.0.0.tgz",
-            "integrity": "sha512-LyXq1bbl0yG0Ai1SbLxIk8ZxUOe3AjnlwE6sVRQmMgetBk+4gY9EO3d00zlEt8Y8gwsITytDnPORl8al7InTjg==",
-            "dev": true,
-            "dependencies": {
-                "compare-func": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=16"
+                "node": ">=18"
             }
         },
         "node_modules/conventional-changelog-preset-loader": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-4.1.0.tgz",
-            "integrity": "sha512-HozQjJicZTuRhCRTq4rZbefaiCzRM2pr6u2NL3XhrmQm4RMnDXfESU6JKu/pnKwx5xtdkYfNCsbhN5exhiKGJA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
+            "integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             }
         },
         "node_modules/conventional-changelog-writer": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-7.0.1.tgz",
-            "integrity": "sha512-Uo+R9neH3r/foIvQ0MKcsXkX642hdm9odUp7TqgFS7BsalTcjzRlIfWZrZR1gbxOozKucaKt5KAbjW8J8xRSmA==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+            "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "conventional-commits-filter": "^4.0.0",
+                "@simple-libs/stream-utils": "^1.2.0",
+                "conventional-commits-filter": "^5.0.0",
                 "handlebars": "^4.7.7",
-                "json-stringify-safe": "^5.0.1",
-                "meow": "^12.0.1",
-                "semver": "^7.5.2",
-                "split2": "^4.0.0"
-            },
-            "bin": {
-                "conventional-changelog-writer": "cli.mjs"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/conventional-commits-filter": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
-            "integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/conventional-commits-parser": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
-            "integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
-            "dev": true,
-            "dependencies": {
-                "is-text-path": "^2.0.0",
-                "JSONStream": "^1.3.5",
-                "meow": "^12.0.1",
-                "split2": "^4.0.0"
-            },
-            "bin": {
-                "conventional-commits-parser": "cli.mjs"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/conventional-recommended-bump": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-9.0.0.tgz",
-            "integrity": "sha512-HR1yD0G5HgYAu6K0wJjLd7QGRK8MQDqqj6Tn1n/ja1dFwBCE6QmV+iSgQ5F7hkx7OUR/8bHpxJqYtXj2f/opPQ==",
-            "dev": true,
-            "dependencies": {
-                "conventional-changelog-preset-loader": "^4.1.0",
-                "conventional-commits-filter": "^4.0.0",
-                "conventional-commits-parser": "^5.0.0",
-                "git-raw-commits": "^4.0.0",
-                "git-semver-tags": "^7.0.0",
-                "meow": "^12.0.1"
-            },
-            "bin": {
-                "conventional-recommended-bump": "cli.mjs"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/conventional-recommended-bump/node_modules/git-semver-tags": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-7.0.1.tgz",
-            "integrity": "sha512-NY0ZHjJzyyNXHTDZmj+GG7PyuAKtMsyWSwh07CR2hOZFa+/yoTsXci/nF2obzL8UDhakFNkD9gNdt/Ed+cxh2Q==",
-            "dev": true,
-            "dependencies": {
-                "meow": "^12.0.1",
+                "meow": "^13.0.0",
                 "semver": "^7.5.2"
             },
             "bin": {
-                "git-semver-tags": "cli.mjs"
+                "conventional-changelog-writer": "dist/cli/index.js"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-commits-filter": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+            "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-commits-parser": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+            "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@simple-libs/stream-utils": "^1.2.0",
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/conventional-recommended-bump": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-11.2.0.tgz",
+            "integrity": "sha512-lqIdmw330QdMBgfL0e6+6q5OMKyIpy4OZNmepit6FS3GldhkG+70drZjuZ0A5NFpze5j85dlYs3GabQXl6sMHw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@conventional-changelog/git-client": "^2.5.1",
+                "conventional-changelog-preset-loader": "^5.0.0",
+                "conventional-commits-filter": "^5.0.0",
+                "conventional-commits-parser": "^6.1.0",
+                "meow": "^13.0.0"
+            },
+            "bin": {
+                "conventional-recommended-bump": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/convert-source-map": {
@@ -4388,32 +4660,6 @@
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true
-        },
-        "node_modules/cosmiconfig": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-            "dev": true,
-            "dependencies": {
-                "env-paths": "^2.2.1",
-                "import-fresh": "^3.3.0",
-                "js-yaml": "^4.1.0",
-                "parse-json": "^5.2.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/d-fischer"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.9.5"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/create-jest": {
             "version": "29.7.0",
@@ -4468,31 +4714,34 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/crypto-random-string": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
-            "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+        "node_modules/css-select": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
-                "type-fest": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=12"
+                "boolbase": "^1.0.0",
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "nth-check": "^2.0.1"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://github.com/sponsors/fb55"
             }
         },
-        "node_modules/crypto-random-string/node_modules/type-fest": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+        "node_modules/css-what": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "engines": {
-                "node": ">=10"
+                "node": ">= 6"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://github.com/sponsors/fb55"
             }
         },
         "node_modules/cssstyle": {
@@ -4504,18 +4753,6 @@
             },
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/dargs": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
-            "integrity": "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/data-uri-to-buffer": {
@@ -4604,9 +4841,10 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -4668,6 +4906,7 @@
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "dev": true,
+            "optional": true,
             "engines": {
                 "node": ">=4.0.0"
             }
@@ -4688,10 +4927,11 @@
             }
         },
         "node_modules/default-browser": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-            "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "bundle-name": "^4.1.0",
                 "default-browser-id": "^5.0.0"
@@ -4704,10 +4944,11 @@
             }
         },
         "node_modules/default-browser-id": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-            "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -4756,6 +4997,7 @@
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
             "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -4780,6 +5022,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/defu": {
+            "version": "6.1.7",
+            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+            "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/degenerator": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -4802,11 +5051,12 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/deprecation": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-            "dev": true
+        "node_modules/destr": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+            "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/detect-indent": {
             "version": "7.0.1",
@@ -4875,16 +5125,89 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/domelementtype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
         "node_modules/dot-prop": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
             "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-obj": "^2.0.0"
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+            "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
             }
         },
         "node_modules/dunder-proto": {
@@ -4905,7 +5228,8 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "node_modules/ejs": {
             "version": "3.1.10",
@@ -4963,6 +5287,33 @@
                 "iconv-lite": "^0.6.2"
             }
         },
+        "node_modules/encoding-sniffer": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+            "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "^0.6.3",
+                "whatwg-encoding": "^3.1.1"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+            }
+        },
+        "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/encoding/node_modules/iconv-lite": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -4988,6 +5339,7 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
             "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
             "engines": {
                 "node": ">=0.12"
             },
@@ -5000,6 +5352,7 @@
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
             "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
             "dev": true,
+            "optional": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5169,18 +5522,6 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/escape-goat": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
-            "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/escape-string-regexp": {
@@ -5586,6 +5927,19 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/eta": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/eta/-/eta-4.5.1.tgz",
+            "integrity": "sha512-EaNCGm+8XEIU7YNcc+THptWAO5NfKBHHARxt+wxZljj9bTr/+arRoOm9/MpGt4n6xn9fLnPFRSoLD0WFYGFUxQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/bgub/eta?sponsor=1"
+            }
+        },
         "node_modules/event-target-shim": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -5672,6 +6026,13 @@
             "dev": true,
             "optional": true
         },
+        "node_modules/exsolve": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+            "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5692,6 +6053,23 @@
                 "node": ">=4"
             }
         },
+        "node_modules/fast-content-type-parse": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+            "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/fast-copy": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
@@ -5704,16 +6082,17 @@
             "dev": true
         },
         "node_modules/fast-glob": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
                 "glob-parent": "^5.1.2",
                 "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
+                "micromatch": "^4.0.8"
             },
             "engines": {
                 "node": ">=8.6.0"
@@ -5756,6 +6135,23 @@
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
             "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
         },
+        "node_modules/fast-string-truncated-width": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+            "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-string-width": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+            "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-string-truncated-width": "^3.0.2"
+            }
+        },
         "node_modules/fast-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -5772,6 +6168,16 @@
                 }
             ],
             "optional": true
+        },
+        "node_modules/fast-wrap-ansi": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+            "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-string-width": "^3.0.2"
+            }
         },
         "node_modules/fastq": {
             "version": "1.17.1",
@@ -5791,27 +6197,14 @@
                 "bser": "2.1.1"
             }
         },
-        "node_modules/fetch-blob": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+        "node_modules/fd-package-json": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+            "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
             "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
+            "license": "MIT",
             "dependencies": {
-                "node-domexception": "^1.0.0",
-                "web-streams-polyfill": "^3.0.3"
-            },
-            "engines": {
-                "node": "^12.20 || >= 14.13"
+                "walk-up-path": "^4.0.0"
             }
         },
         "node_modules/figures": {
@@ -5891,7 +6284,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -6008,27 +6401,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/form-data-encoder": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
-            "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 14.17"
-            }
-        },
-        "node_modules/formdata-polyfill": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-            "dev": true,
-            "dependencies": {
-                "fetch-blob": "^3.1.2"
-            },
-            "engines": {
-                "node": ">=12.20.0"
-            }
-        },
         "node_modules/fs-constants": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -6072,7 +6444,6 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "os": [
@@ -6142,10 +6513,11 @@
             }
         },
         "node_modules/get-east-asian-width": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
-            "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+            "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -6242,128 +6614,43 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/git-raw-commits": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz",
-            "integrity": "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==",
+        "node_modules/giget": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+            "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "dargs": "^8.0.0",
-                "meow": "^12.0.1",
-                "split2": "^4.0.0"
+                "citty": "^0.1.6",
+                "consola": "^3.4.0",
+                "defu": "^6.1.4",
+                "node-fetch-native": "^1.6.6",
+                "nypm": "^0.6.0",
+                "pathe": "^2.0.3"
             },
             "bin": {
-                "git-raw-commits": "cli.mjs"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/git-semver-tags": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-8.0.1.tgz",
-            "integrity": "sha512-zMbamckSNdlT4U48IMFa2Cn6FTzM+2yF6/gEmStPJI8PiLxd/bT6dw10+mc6u5Qe4fhrc/y9nU290FWjQhAV7g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@conventional-changelog/git-client": "^2.6.0",
-                "meow": "^13.0.0"
-            },
-            "bin": {
-                "git-semver-tags": "src/cli.js"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/git-semver-tags/node_modules/@conventional-changelog/git-client": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
-            "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@simple-libs/child-process-utils": "^1.0.0",
-                "@simple-libs/stream-utils": "^1.2.0",
-                "semver": "^7.5.2"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "conventional-commits-filter": "^5.0.0",
-                "conventional-commits-parser": "^6.4.0"
-            },
-            "peerDependenciesMeta": {
-                "conventional-commits-filter": {
-                    "optional": true
-                },
-                "conventional-commits-parser": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/git-semver-tags/node_modules/conventional-commits-filter": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-            "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/git-semver-tags/node_modules/conventional-commits-parser": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
-            "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@simple-libs/stream-utils": "^1.2.0",
-                "meow": "^13.0.0"
-            },
-            "bin": {
-                "conventional-commits-parser": "dist/cli/index.js"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/git-semver-tags/node_modules/meow": {
-            "version": "13.2.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "giget": "dist/cli.mjs"
             }
         },
         "node_modules/git-up": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/git-up/-/git-up-7.0.0.tgz",
-            "integrity": "sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/git-up/-/git-up-8.1.1.tgz",
+            "integrity": "sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-ssh": "^1.4.0",
-                "parse-url": "^8.1.0"
+                "parse-url": "^9.2.0"
             }
         },
         "node_modules/git-url-parse": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-14.0.0.tgz",
-            "integrity": "sha512-NnLweV+2A4nCvn4U/m2AoYu0pPKlsmhK9cknG7IMwsjFY1S2jxM+mAhsDxyxfCIGfGaD+dozsyX4b6vkYc83yQ==",
+            "version": "16.1.0",
+            "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.1.0.tgz",
+            "integrity": "sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "git-up": "^7.0.0"
+                "git-up": "^8.1.0"
             }
         },
         "node_modules/github-from-package": {
@@ -6404,30 +6691,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/global-directory": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
-            "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
-            "dev": true,
-            "dependencies": {
-                "ini": "4.1.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/global-directory/node_modules/ini": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
-            "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
-            "dev": true,
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/globals": {
@@ -6656,15 +6919,16 @@
             "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="
         },
         "node_modules/hosted-git-info": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-            "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+            "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "lru-cache": "^10.0.1"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/hpagent": {
@@ -6692,6 +6956,39 @@
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
             "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
+        },
+        "node_modules/htmlparser2": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+            "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.2.2",
+                "entities": "^7.0.1"
+            }
+        },
+        "node_modules/htmlparser2/node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/http-cache-semantics": {
             "version": "4.1.1",
@@ -6797,15 +7094,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/import-lazy": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-            "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/import-local": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -6859,12 +7147,13 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/ini": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
-            "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
+            "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
             "dev": true,
+            "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/inquirer": {
@@ -6962,6 +7251,20 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "binary-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-boolean-object": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
@@ -7051,6 +7354,7 @@
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
             "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "is-docker": "cli.js"
             },
@@ -7065,7 +7369,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7091,7 +7395,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -7099,16 +7403,14 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-in-ci": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-0.1.0.tgz",
-            "integrity": "sha512-d9PXLEY0v1iJ64xLiQMJ51J128EYHAaOR4yZqQi8aHGfw6KgifM3/Viw1oZZ1GCVmb3gBuyhLyHj0HgR2DhSXQ==",
+        "node_modules/is-in-ssh": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+            "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
             "dev": true,
-            "bin": {
-                "is-in-ci": "cli.js"
-            },
+            "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -7119,6 +7421,7 @@
             "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
             "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-docker": "^3.0.0"
             },
@@ -7127,22 +7430,6 @@
             },
             "engines": {
                 "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-installed-globally": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
-            "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
-            "dev": true,
-            "dependencies": {
-                "global-directory": "^4.0.1",
-                "is-path-inside": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -7168,23 +7455,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-npm": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.0.0.tgz",
-            "integrity": "sha512-JEjxbSmtPSt1c8XTkVrlujcXdKV1/tvuQ7GwKcAlyiVLeYFQ2VHat8xfrDJsIkhCdF/tZ7CiIR3sy141c6+gPQ==",
-            "dev": true,
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -7209,6 +7484,7 @@
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
             "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -7222,18 +7498,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/is-path-inside": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-            "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-potential-custom-element-name": {
@@ -7278,10 +7542,11 @@
             }
         },
         "node_modules/is-ssh": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
-            "integrity": "sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.1.tgz",
+            "integrity": "sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "protocols": "^2.0.1"
             }
@@ -7327,18 +7592,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-text-path": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
-            "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
-            "dev": true,
-            "dependencies": {
-                "text-extensions": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/is-typed-array": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
@@ -7353,12 +7606,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-            "dev": true
         },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
@@ -7384,10 +7631,11 @@
             }
         },
         "node_modules/is-wsl": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-            "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-inside-container": "^1.0.0"
             },
@@ -8101,6 +8349,16 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/jiti": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jiti": "lib/jiti-cli.mjs"
+            }
+        },
         "node_modules/joycon": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -8208,11 +8466,12 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
         },
-        "node_modules/json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-            "dev": true
+        "node_modules/json-with-bigint": {
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+            "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -8237,31 +8496,6 @@
                 "graceful-fs": "^4.1.6"
             }
         },
-        "node_modules/jsonparse": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-            "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
-            "dev": true,
-            "engines": [
-                "node >= 0.2.0"
-            ]
-        },
-        "node_modules/JSONStream": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-            "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-            "dev": true,
-            "dependencies": {
-                "jsonparse": "^1.2.0",
-                "through": ">=2.2.7 <3"
-            },
-            "bin": {
-                "JSONStream": "bin.js"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/keyv": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8277,33 +8511,6 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/ky": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/ky/-/ky-1.7.2.tgz",
-            "integrity": "sha512-OzIvbHKKDpi60TnF9t7UUVAF1B4mcqc02z5PIvrm08Wyb+yOcz63GRvEuVxNT18a9E1SrNouhB4W2NNLeD7Ykg==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/ky?sponsor=1"
-            }
-        },
-        "node_modules/latest-version": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-9.0.0.tgz",
-            "integrity": "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==",
-            "dev": true,
-            "dependencies": {
-                "package-json": "^10.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/leven": {
@@ -8346,10 +8553,11 @@
             }
         },
         "node_modules/lilconfig": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
-            "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+            "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14"
             },
@@ -8364,21 +8572,22 @@
             "dev": true
         },
         "node_modules/lint-staged": {
-            "version": "15.2.10",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.10.tgz",
-            "integrity": "sha512-5dY5t743e1byO19P9I4b3x8HJwalIznL5E1FWYnU6OWw33KxNBSLAc6Cy7F2PsFEO8FKnLwjwm5hx7aMF0jzZg==",
+            "version": "15.5.2",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
+            "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "chalk": "~5.3.0",
-                "commander": "~12.1.0",
-                "debug": "~4.3.6",
-                "execa": "~8.0.1",
-                "lilconfig": "~3.1.2",
-                "listr2": "~8.2.4",
-                "micromatch": "~4.0.8",
-                "pidtree": "~0.6.0",
-                "string-argv": "~0.3.2",
-                "yaml": "~2.5.0"
+                "chalk": "^5.4.1",
+                "commander": "^13.1.0",
+                "debug": "^4.4.0",
+                "execa": "^8.0.1",
+                "lilconfig": "^3.1.3",
+                "listr2": "^8.2.5",
+                "micromatch": "^4.0.8",
+                "pidtree": "^0.6.0",
+                "string-argv": "^0.3.2",
+                "yaml": "^2.7.0"
             },
             "bin": {
                 "lint-staged": "bin/lint-staged.js"
@@ -8391,15 +8600,26 @@
             }
         },
         "node_modules/lint-staged/node_modules/chalk": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/lint-staged/node_modules/commander": {
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+            "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/lint-staged/node_modules/execa": {
@@ -9093,9 +9313,10 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "license": "MIT"
         },
         "node_modules/lodash-es": {
             "version": "4.18.1",
@@ -9344,10 +9565,11 @@
             "dev": true
         },
         "node_modules/macos-release": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.3.0.tgz",
-            "integrity": "sha512-tPJQ1HeyiU2vRruNGhZ+VleWuMQRro8iFtJxYgnS4NQe+EukKF6aGiIT+7flZhISAt2iaXBCfFGvAyif7/f8nQ==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.4.0.tgz",
+            "integrity": "sha512-wpGPwyg/xrSp4H4Db4xYSeAr6+cFQGHfspHzDUdYxswDnUW0L5Ov63UuJiSr8NMSpyaChO4u1n0MXUvVPtrN6A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -9418,12 +9640,13 @@
             }
         },
         "node_modules/meow": {
-            "version": "12.1.1",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
-            "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=16.10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -9774,7 +9997,8 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/netmask": {
             "version": "2.0.2",
@@ -9825,51 +10049,12 @@
                 "node": ">=10"
             }
         },
-        "node_modules/node-domexception": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+        "node_modules/node-fetch-native": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+            "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
             "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "github",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "engines": {
-                "node": ">=10.5.0"
-            }
-        },
-        "node_modules/node-fetch": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-            "dev": true,
-            "dependencies": {
-                "data-uri-to-buffer": "^4.0.0",
-                "fetch-blob": "^3.1.4",
-                "formdata-polyfill": "^4.0.10"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/node-fetch"
-            }
-        },
-        "node_modules/node-fetch/node_modules/data-uri-to-buffer": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-            "dev": true,
-            "engines": {
-                "node": ">= 12"
-            }
+            "license": "MIT"
         },
         "node_modules/node-gyp": {
             "version": "11.5.0",
@@ -9956,24 +10141,25 @@
             }
         },
         "node_modules/normalize-package-data": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-            "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.1.tgz",
+            "integrity": "sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
-                "hosted-git-info": "^7.0.0",
+                "hosted-git-info": "^8.0.0",
                 "semver": "^7.3.5",
                 "validate-npm-package-license": "^3.0.4"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9998,6 +10184,19 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/nth-check": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
         "node_modules/number-is-nan": {
@@ -10044,6 +10243,31 @@
             "version": "2.2.13",
             "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.13.tgz",
             "integrity": "sha512-cTGB9ptp9dY9A5VbMSe7fQBcl/tt22Vcqdq8+eN93rblOuE0aCFu4aZ2vMwct/2t+lFnosm8RkQW1I0Omb1UtQ=="
+        },
+        "node_modules/nypm": {
+            "version": "0.6.6",
+            "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
+            "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "citty": "^0.2.2",
+                "pathe": "^2.0.3",
+                "tinyexec": "^1.1.1"
+            },
+            "bin": {
+                "nypm": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/nypm/node_modules/citty": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+            "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
@@ -10123,6 +10347,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/ohash": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+            "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/on-exit-leak-free": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -10154,18 +10385,21 @@
             }
         },
         "node_modules/open": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
-            "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+            "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "default-browser": "^5.2.1",
+                "default-browser": "^5.4.0",
                 "define-lazy-prop": "^3.0.0",
+                "is-in-ssh": "^1.0.0",
                 "is-inside-container": "^1.0.0",
-                "is-wsl": "^3.1.0"
+                "powershell-utils": "^0.1.0",
+                "wsl-utils": "^0.3.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -10226,27 +10460,20 @@
             }
         },
         "node_modules/os-name": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/os-name/-/os-name-5.1.0.tgz",
-            "integrity": "sha512-YEIoAnM6zFmzw3PQ201gCVCIWbXNyKObGlVvpAVvraAeOHnlYVKFssbA/riRX5R40WA6kKrZ7Dr7dWzO3nKSeQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/os-name/-/os-name-7.0.0.tgz",
+            "integrity": "sha512-/HfRU/lPPr4T2VigM+cvM3cU77es+XF4OEAa4aE5zpdvrxHGD2NmH0AFIWpMNAb+CsZL45rlcIO49Re0ZcRseg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "macos-release": "^3.1.0",
-                "windows-release": "^5.0.1"
+                "macos-release": "^3.4.0",
+                "windows-release": "^7.1.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/p-cancelable": {
@@ -10356,24 +10583,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/package-json": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
-            "integrity": "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==",
-            "dev": true,
-            "dependencies": {
-                "ky": "^1.2.0",
-                "registry-auth-token": "^5.0.2",
-                "registry-url": "^6.0.1",
-                "semver": "^7.6.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -10418,32 +10627,78 @@
             }
         },
         "node_modules/parse-path": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
-            "integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
+            "integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "protocols": "^2.0.0"
             }
         },
         "node_modules/parse-url": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-8.1.0.tgz",
-            "integrity": "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-9.2.0.tgz",
+            "integrity": "sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
+                "@types/parse-path": "^7.0.0",
                 "parse-path": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=14.13.0"
             }
         },
         "node_modules/parse5": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-            "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "license": "MIT",
             "dependencies": {
-                "entities": "^4.4.0"
+                "entities": "^6.0.0"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5-htmlparser2-tree-adapter": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+            "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "domhandler": "^5.0.3",
+                "parse5": "^7.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5-parser-stream": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+            "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parse5": "^7.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/path-exists": {
@@ -10504,6 +10759,20 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/perfect-debounce": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+            "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -10515,7 +10784,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -10706,6 +10975,18 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pkg-types": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+            "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "confbox": "^0.2.4",
+                "exsolve": "^1.0.8",
+                "pathe": "^2.0.3"
+            }
+        },
         "node_modules/possible-typed-array-names": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -10713,6 +10994,19 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/powershell-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+            "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/prebuild-install": {
@@ -10864,17 +11158,12 @@
             "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
             "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA=="
         },
-        "node_modules/proto-list": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-            "dev": true
-        },
         "node_modules/protocols": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
-            "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
-            "dev": true
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
+            "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/proxy": {
             "version": "1.0.2",
@@ -10952,21 +11241,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/pupa": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.1.0.tgz",
-            "integrity": "sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==",
-            "dev": true,
-            "dependencies": {
-                "escape-goat": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/pure-rand": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -11019,6 +11293,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/quickjs-wasi": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-0.0.1.tgz",
+            "integrity": "sha512-fBWNLTBkxkLAhe1AzF1hyXEvuA+N+vV1WMP2D6iiMUblvmOt8Pp5t8zUcgvz7aYA1ldUdxDlgUse15dmcKjkNg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/railroad-diagrams": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
@@ -11045,6 +11326,7 @@
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
+            "optional": true,
             "dependencies": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -11059,15 +11341,28 @@
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "node_modules/rc/node_modules/strip-json-comments": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
             "dev": true,
+            "optional": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/rc9": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+            "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "defu": "^6.1.4",
+                "destr": "^2.0.3"
             }
         },
         "node_modules/react-is": {
@@ -11075,196 +11370,6 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
             "dev": true
-        },
-        "node_modules/read-pkg": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-8.1.0.tgz",
-            "integrity": "sha512-PORM8AgzXeskHO/WEv312k9U03B8K9JSiWF/8N9sUuFjBa+9SF2u6K7VClzXwDXab51jCd8Nd36CNM+zR97ScQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/normalize-package-data": "^2.4.1",
-                "normalize-package-data": "^6.0.0",
-                "parse-json": "^7.0.0",
-                "type-fest": "^4.2.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg-up": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-10.1.0.tgz",
-            "integrity": "sha512-aNtBq4jR8NawpKJQldrQcSW9y/d+KWH4v24HWkHljOZ7H0av+YTGANBzRh9A5pw7v/bLVsLVPpOhJ7gHNVy8lA==",
-            "dev": true,
-            "dependencies": {
-                "find-up": "^6.3.0",
-                "read-pkg": "^8.1.0",
-                "type-fest": "^4.2.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/find-up": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-            "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-            "dev": true,
-            "dependencies": {
-                "locate-path": "^7.1.0",
-                "path-exists": "^5.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/locate-path": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-            "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-            "dev": true,
-            "dependencies": {
-                "p-locate": "^6.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/p-limit": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-            "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-            "dev": true,
-            "dependencies": {
-                "yocto-queue": "^1.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/p-locate": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-            "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-            "dev": true,
-            "dependencies": {
-                "p-limit": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/path-exists": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-            "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-            "dev": true,
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/type-fest": {
-            "version": "4.26.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
-            "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/yocto-queue": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-            "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg/node_modules/json-parse-even-better-errors": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
-            "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
-            "dev": true,
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/read-pkg/node_modules/lines-and-columns": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
-            "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
-            "dev": true,
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            }
-        },
-        "node_modules/read-pkg/node_modules/parse-json": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
-            "integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/code-frame": "^7.21.4",
-                "error-ex": "^1.3.2",
-                "json-parse-even-better-errors": "^3.0.0",
-                "lines-and-columns": "^2.0.3",
-                "type-fest": "^3.8.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg/node_modules/parse-json/node_modules/type-fest": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-            "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-            "dev": true,
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg/node_modules/type-fest": {
-            "version": "4.26.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
-            "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/readable-stream": {
             "version": "3.6.2",
@@ -11277,6 +11382,20 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
             }
         },
         "node_modules/real-require": {
@@ -11329,37 +11448,10 @@
                 "url": "https://github.com/sponsors/mysticatea"
             }
         },
-        "node_modules/registry-auth-token": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
-            "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
-            "dev": true,
-            "dependencies": {
-                "@pnpm/npm-conf": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/registry-url": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
-            "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
-            "dev": true,
-            "dependencies": {
-                "rc": "1.2.8"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/release-it": {
-            "version": "17.6.0",
-            "resolved": "https://registry.npmjs.org/release-it/-/release-it-17.6.0.tgz",
-            "integrity": "sha512-EE34dtRPL7BHpYQC7E+zAU8kjkyxFHxLk5Iqnmn/5nGcjgOQu34Au29M2V9YvxiP3tZbIlEn4gItEzu7vAPRbw==",
+            "version": "20.0.0",
+            "resolved": "https://registry.npmjs.org/release-it/-/release-it-20.0.0.tgz",
+            "integrity": "sha512-KLCgEJH+t/MnJieOzjcroFcTSFY8dw44HT9joMm6+R5hPa+h2qPrDhHHZ5eN6m1yx8KK+q7KNdM7AfJYfAVFvQ==",
             "dev": true,
             "funding": [
                 {
@@ -11371,70 +11463,55 @@
                     "url": "https://opencollective.com/webpro"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "@iarna/toml": "2.2.5",
-                "@octokit/rest": "20.1.1",
+                "@inquirer/prompts": "8.3.2",
+                "@nodeutils/defaults-deep": "1.1.0",
+                "@octokit/rest": "22.0.1",
+                "@phun-ky/typeof": "2.0.3",
                 "async-retry": "1.3.3",
-                "chalk": "5.3.0",
-                "cosmiconfig": "9.0.0",
-                "execa": "8.0.1",
-                "git-url-parse": "14.0.0",
-                "globby": "14.0.2",
-                "got": "13.0.0",
-                "inquirer": "9.3.2",
-                "is-ci": "3.0.1",
+                "c12": "3.3.3",
+                "ci-info": "^4.4.0",
+                "eta": "4.5.1",
+                "git-url-parse": "16.1.0",
                 "issue-parser": "7.0.1",
-                "lodash": "4.17.21",
-                "mime-types": "2.1.35",
+                "lodash.merge": "4.6.2",
+                "mime-types": "3.0.2",
                 "new-github-release-url": "2.0.0",
-                "node-fetch": "3.3.2",
-                "open": "10.1.0",
-                "ora": "8.0.1",
-                "os-name": "5.1.0",
-                "proxy-agent": "6.4.0",
-                "semver": "7.6.2",
-                "shelljs": "0.8.5",
-                "update-notifier": "7.1.0",
+                "open": "11.0.0",
+                "ora": "9.3.0",
+                "os-name": "7.0.0",
+                "proxy-agent": "7.0.0",
+                "semver": "7.7.4",
+                "tinyglobby": "0.2.15",
+                "undici": "7.24.5",
                 "url-join": "5.0.0",
-                "wildcard-match": "5.1.3",
-                "yargs-parser": "21.1.1"
+                "wildcard-match": "5.1.4",
+                "yargs-parser": "22.0.0"
             },
             "bin": {
                 "release-it": "bin/release-it.js"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || ^22.0.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
             }
         },
-        "node_modules/release-it/node_modules/@sindresorhus/is": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
-            "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+        "node_modules/release-it/node_modules/agent-base": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
+            "integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/is?sponsor=1"
-            }
-        },
-        "node_modules/release-it/node_modules/@szmarczak/http-timer": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-            "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
-            "dev": true,
-            "dependencies": {
-                "defer-to-connect": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=14.16"
+                "node": ">= 14"
             }
         },
         "node_modules/release-it/node_modules/ansi-regex": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -11442,38 +11519,12 @@
                 "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
-        "node_modules/release-it/node_modules/cacheable-lookup": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-            "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
-            "dev": true,
-            "engines": {
-                "node": ">=14.16"
-            }
-        },
-        "node_modules/release-it/node_modules/cacheable-request": {
-            "version": "10.2.14",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
-            "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/http-cache-semantics": "^4.0.2",
-                "get-stream": "^6.0.1",
-                "http-cache-semantics": "^4.1.1",
-                "keyv": "^4.5.3",
-                "mimic-response": "^4.0.0",
-                "normalize-url": "^8.0.0",
-                "responselike": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            }
-        },
         "node_modules/release-it/node_modules/chalk": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -11481,221 +11532,157 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/release-it/node_modules/cli-width": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-            "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+        "node_modules/release-it/node_modules/ci-info": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
             "engines": {
-                "node": ">= 12"
+                "node": ">=8"
             }
         },
-        "node_modules/release-it/node_modules/emoji-regex": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-            "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-            "dev": true
-        },
-        "node_modules/release-it/node_modules/execa": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-            "dev": true,
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^8.0.1",
-                "human-signals": "^5.0.0",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=16.17"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/release-it/node_modules/execa/node_modules/get-stream": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-            "dev": true,
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/release-it/node_modules/globby": {
-            "version": "14.0.2",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
-            "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
-            "dev": true,
-            "dependencies": {
-                "@sindresorhus/merge-streams": "^2.1.0",
-                "fast-glob": "^3.3.2",
-                "ignore": "^5.2.4",
-                "path-type": "^5.0.0",
-                "slash": "^5.1.0",
-                "unicorn-magic": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/release-it/node_modules/got": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
-            "integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
-            "dev": true,
-            "dependencies": {
-                "@sindresorhus/is": "^5.2.0",
-                "@szmarczak/http-timer": "^5.0.1",
-                "cacheable-lookup": "^7.0.0",
-                "cacheable-request": "^10.2.8",
-                "decompress-response": "^6.0.0",
-                "form-data-encoder": "^2.1.2",
-                "get-stream": "^6.0.1",
-                "http2-wrapper": "^2.1.10",
-                "lowercase-keys": "^3.0.0",
-                "p-cancelable": "^3.0.0",
-                "responselike": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/got?sponsor=1"
-            }
-        },
-        "node_modules/release-it/node_modules/http2-wrapper": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-            "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
-            "dev": true,
-            "dependencies": {
-                "quick-lru": "^5.1.1",
-                "resolve-alpn": "^1.2.0"
-            },
-            "engines": {
-                "node": ">=10.19.0"
-            }
-        },
-        "node_modules/release-it/node_modules/human-signals": {
+        "node_modules/release-it/node_modules/cli-cursor": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
             "dev": true,
-            "engines": {
-                "node": ">=16.17.0"
-            }
-        },
-        "node_modules/release-it/node_modules/inquirer": {
-            "version": "9.3.2",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.3.2.tgz",
-            "integrity": "sha512-+ynEbhWKhyomnaX0n2aLIMSkgSlGB5RrWbNXnEqj6mdaIydu6y40MdBjL38SAB0JcdmOaIaMua1azdjLEr3sdw==",
-            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@inquirer/figures": "^1.0.3",
-                "ansi-escapes": "^4.3.2",
-                "cli-width": "^4.1.0",
-                "external-editor": "^3.1.0",
-                "mute-stream": "1.0.0",
-                "ora": "^5.4.1",
-                "run-async": "^3.0.0",
-                "rxjs": "^7.8.1",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^6.2.0",
-                "yoctocolors-cjs": "^2.1.1"
+                "restore-cursor": "^5.0.0"
             },
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/release-it/node_modules/inquirer/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/release-it/node_modules/inquirer/node_modules/log-symbols": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^4.1.0",
-                "is-unicode-supported": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/release-it/node_modules/inquirer/node_modules/ora": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-            "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+        "node_modules/release-it/node_modules/cli-spinners": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+            "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
             "dev": true,
-            "dependencies": {
-                "bl": "^4.1.0",
-                "chalk": "^4.1.0",
-                "cli-cursor": "^3.1.0",
-                "cli-spinners": "^2.5.0",
-                "is-interactive": "^1.0.0",
-                "is-unicode-supported": "^0.1.0",
-                "log-symbols": "^4.1.0",
-                "strip-ansi": "^6.0.0",
-                "wcwidth": "^1.0.1"
-            },
+            "license": "MIT",
             "engines": {
-                "node": ">=10"
+                "node": ">=18.20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/release-it/node_modules/is-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+        "node_modules/release-it/node_modules/data-uri-to-buffer": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-7.0.0.tgz",
+            "integrity": "sha512-CuRUx0TXGSbbWdEci3VK/XOZGP3n0P4pIKpsqpVtBqaIIuj3GKK8H45oAqA4Rg8FHipc+CzRdUzmD4YQXxv66Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">= 14"
+            }
+        },
+        "node_modules/release-it/node_modules/degenerator": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-6.0.0.tgz",
+            "integrity": "sha512-j5MdXdefrecJeSqTpUrgZd4fBsD2IxZx0JlJD+n1Q7+aTf7/HcyXSfHsicPW6ekPurX159v1ZYla6OJgSPh2Dw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ast-types": "^0.13.4",
+                "escodegen": "^2.1.0",
+                "esprima": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14"
+            },
+            "peerDependencies": {
+                "quickjs-wasi": "^0.0.1"
+            }
+        },
+        "node_modules/release-it/node_modules/get-uri": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-7.0.0.tgz",
+            "integrity": "sha512-ZsC7KQxm1Hra8yO0RvMZ4lGJT7vnBtSNpEHKq39MPN7vjuvCiu1aQ8rkXUaIXG1y/TSDez97Gmv04ibnYqCp/A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "basic-ftp": "^5.0.2",
+                "data-uri-to-buffer": "7.0.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/release-it/node_modules/http-proxy-agent": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-8.0.0.tgz",
+            "integrity": "sha512-7pose0uGgrCJeH2Qh4JcNhWZp3u/oNrWjNYDK4ydOLxOpTw8V8ogHFAmkz0VWq96JBFj4umVJpvmQi287rSYLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "8.0.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/release-it/node_modules/https-proxy-agent": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
+            "integrity": "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "8.0.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/release-it/node_modules/is-interactive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+            "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/release-it/node_modules/is-unicode-supported": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/release-it/node_modules/log-symbols": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-            "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+            "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "chalk": "^5.3.0",
-                "is-unicode-supported": "^1.3.0"
+                "is-unicode-supported": "^2.0.0",
+                "yoctocolors": "^2.1.1"
             },
             "engines": {
                 "node": ">=18"
@@ -11704,160 +11691,149 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/release-it/node_modules/log-symbols/node_modules/is-unicode-supported": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-            "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+        "node_modules/release-it/node_modules/lru-cache": {
+            "version": "7.18.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
             "dev": true,
+            "license": "ISC",
             "engines": {
                 "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/release-it/node_modules/lowercase-keys": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-            "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+        "node_modules/release-it/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">= 0.6"
             }
         },
-        "node_modules/release-it/node_modules/mimic-fn": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+        "node_modules/release-it/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
             "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/release-it/node_modules/mimic-response": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
-            "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
-            "dev": true,
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/release-it/node_modules/mute-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-            "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-            "dev": true,
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/release-it/node_modules/normalize-url": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
-            "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
-            "dev": true,
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/release-it/node_modules/npm-run-path": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "path-key": "^4.0.0"
+                "mime-db": "^1.54.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/release-it/node_modules/onetime": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "mimic-fn": "^4.0.0"
+                "mimic-function": "^5.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/release-it/node_modules/ora": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-8.0.1.tgz",
-            "integrity": "sha512-ANIvzobt1rls2BDny5fWZ3ZVKyD6nscLvfFRpQgfWsythlcsVUC9kL0zq6j2Z5z9wwp1kd7wpsD/T9qNPVLCaQ==",
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
+            "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "chalk": "^5.3.0",
-                "cli-cursor": "^4.0.0",
-                "cli-spinners": "^2.9.2",
+                "chalk": "^5.6.2",
+                "cli-cursor": "^5.0.0",
+                "cli-spinners": "^3.2.0",
                 "is-interactive": "^2.0.0",
-                "is-unicode-supported": "^2.0.0",
-                "log-symbols": "^6.0.0",
-                "stdin-discarder": "^0.2.1",
-                "string-width": "^7.0.0",
-                "strip-ansi": "^7.1.0"
+                "is-unicode-supported": "^2.1.0",
+                "log-symbols": "^7.0.1",
+                "stdin-discarder": "^0.3.1",
+                "string-width": "^8.1.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/release-it/node_modules/ora/node_modules/cli-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-            "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+        "node_modules/release-it/node_modules/pac-proxy-agent": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-8.0.0.tgz",
+            "integrity": "sha512-HyCoVbyQ/nbVlQ/R6wBu0YXhbG2oAnEK5BQ3xMyj1OffQmU5NoOnpLzgPlKHaobUzz5NK0+AZHby4TdydAEBUA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "restore-cursor": "^4.0.0"
+                "agent-base": "8.0.0",
+                "debug": "^4.3.4",
+                "get-uri": "7.0.0",
+                "http-proxy-agent": "8.0.0",
+                "https-proxy-agent": "8.0.0",
+                "pac-resolver": "8.0.0",
+                "quickjs-wasi": "^0.0.1",
+                "socks-proxy-agent": "9.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">= 14"
             }
         },
-        "node_modules/release-it/node_modules/ora/node_modules/is-interactive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-            "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+        "node_modules/release-it/node_modules/pac-resolver": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-8.0.0.tgz",
+            "integrity": "sha512-SVNzOxVq2zuTew3WAt7U8UghwzJzuWYuJryd3y8FxyLTZdjVoCzY8kLP39PpEqQCDvlMWdQXwViu0sYT3eiU2w==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "degenerator": "6.0.0",
+                "netmask": "^2.0.2"
+            },
             "engines": {
-                "node": ">=12"
+                "node": ">= 14"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+            "peerDependencies": {
+                "quickjs-wasi": "^0.0.1"
             }
         },
-        "node_modules/release-it/node_modules/ora/node_modules/is-unicode-supported": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+        "node_modules/release-it/node_modules/proxy-agent": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-7.0.0.tgz",
+            "integrity": "sha512-okTgt79rHTvMHkr/Ney5rZpgCHh3g1g3tI5uhkgN5b7OeI3n0Q/ui1uv9OdrnZNJM9WIZJqZPh/UJs+YtO/TMQ==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "8.0.0",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "8.0.0",
+                "https-proxy-agent": "8.0.0",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "8.0.0",
+                "proxy-from-env": "^1.1.0",
+                "socks-proxy-agent": "9.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/release-it/node_modules/restore-cursor": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "onetime": "^7.0.0",
+                "signal-exit": "^4.1.0"
+            },
             "engines": {
                 "node": ">=18"
             },
@@ -11865,30 +11841,59 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/release-it/node_modules/ora/node_modules/string-width": {
+        "node_modules/release-it/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/release-it/node_modules/socks-proxy-agent": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-9.0.0.tgz",
+            "integrity": "sha512-fFlbMlfsXhK02ZB8aZY7Hwxh/IHBV9b1Oq9bvBk6tkFWXvdAxUgA0wbw/NYR5liU3Y5+KI6U4FH3kYJt9QYv0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "8.0.0",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/release-it/node_modules/string-width": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/release-it/node_modules/strip-ansi": {
             "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/release-it/node_modules/ora/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
+                "ansi-regex": "^6.2.2"
             },
             "engines": {
                 "node": ">=12"
@@ -11897,155 +11902,14 @@
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
-        "node_modules/release-it/node_modules/p-cancelable": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
-            "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+        "node_modules/release-it/node_modules/undici": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
+            "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=12.20"
-            }
-        },
-        "node_modules/release-it/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/release-it/node_modules/path-type": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
-            "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/release-it/node_modules/responselike": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
-            "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
-            "dev": true,
-            "dependencies": {
-                "lowercase-keys": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/release-it/node_modules/restore-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-            "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
-            "dev": true,
-            "dependencies": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/release-it/node_modules/restore-cursor/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/release-it/node_modules/restore-cursor/node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/release-it/node_modules/restore-cursor/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
-        },
-        "node_modules/release-it/node_modules/run-async": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-            "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.12.0"
-            }
-        },
-        "node_modules/release-it/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/release-it/node_modules/signal-exit": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/release-it/node_modules/slash": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-            "dev": true,
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/release-it/node_modules/strip-final-newline": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=20.18.1"
             }
         },
         "node_modules/release-it/node_modules/url-join": {
@@ -12057,18 +11921,14 @@
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
         },
-        "node_modules/release-it/node_modules/wrap-ansi": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+        "node_modules/release-it/node_modules/yargs-parser": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
             "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
+            "license": "ISC",
             "engines": {
-                "node": ">=8"
+                "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         },
         "node_modules/require-directory": {
@@ -12231,10 +12091,11 @@
             "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="
         },
         "node_modules/run-applescript": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-            "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -12375,30 +12236,16 @@
             "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
         },
         "node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "devOptional": true,
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/semver-diff": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
-            "integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
-            "dev": true,
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/set-function-length": {
@@ -12791,10 +12638,11 @@
             }
         },
         "node_modules/stdin-discarder": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-            "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+            "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -13132,18 +12980,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/text-extensions": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
-            "integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -13168,12 +13004,21 @@
             "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
             "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
         },
+        "node_modules/tinyexec": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+            "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
             "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
             "dev": true,
-            "optional": true,
             "dependencies": {
                 "fdir": "^6.5.0",
                 "picomatch": "^4.0.3"
@@ -13190,7 +13035,6 @@
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
-            "optional": true,
             "engines": {
                 "node": ">=12.0.0"
             },
@@ -13209,7 +13053,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
             "engines": {
                 "node": ">=12"
             },
@@ -13234,14 +13077,12 @@
             "integrity": "sha512-na2EcZqmdA2iV9zHV7OHQDxxdciEpxrjbkp+aHmZgnZKHzoElLajP59np5/4+sare9fQBfixgvXKx8ev1d7ytw=="
         },
         "node_modules/tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dependencies": {
-                "os-tmpdir": "~1.0.2"
-            },
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "license": "MIT",
             "engines": {
-                "node": ">=0.6.0"
+                "node": ">=14.14"
             }
         },
         "node_modules/tmpl": {
@@ -13254,7 +13095,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -13521,15 +13362,6 @@
             "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
             "dev": true
         },
-        "node_modules/typedarray-to-buffer": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "dev": true,
-            "dependencies": {
-                "is-typedarray": "^1.0.0"
-            }
-        },
         "node_modules/typescript": {
             "version": "5.6.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
@@ -13548,6 +13380,7 @@
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
             "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "optional": true,
             "bin": {
                 "uglifyjs": "bin/uglifyjs"
@@ -13571,22 +13404,20 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/undici": {
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+            "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
+            }
+        },
         "node_modules/undici-types": {
             "version": "6.19.8",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
             "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
-        },
-        "node_modules/unicorn-magic": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-            "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/unique-filename": {
             "version": "4.0.0",
@@ -13614,26 +13445,12 @@
                 "node": "^18.17.0 || >=20.5.0"
             }
         },
-        "node_modules/unique-string": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
-            "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
-            "dev": true,
-            "dependencies": {
-                "crypto-random-string": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/universal-user-agent": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-            "dev": true
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+            "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/universalify": {
             "version": "2.0.1",
@@ -13671,44 +13488,6 @@
             },
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
-            }
-        },
-        "node_modules/update-notifier": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.1.0.tgz",
-            "integrity": "sha512-8SV3rIqVY6EFC1WxH6L0j55s0MO79MFBS1pivmInRJg3pCEDgWHBj1Q6XByTtCLOZIFA0f6zoG9ZWf2Ks9lvTA==",
-            "dev": true,
-            "dependencies": {
-                "boxen": "^7.1.1",
-                "chalk": "^5.3.0",
-                "configstore": "^6.0.0",
-                "import-lazy": "^4.0.0",
-                "is-in-ci": "^0.1.0",
-                "is-installed-globally": "^1.0.0",
-                "is-npm": "^6.0.0",
-                "latest-version": "^9.0.0",
-                "pupa": "^3.1.0",
-                "semver": "^7.6.2",
-                "semver-diff": "^4.0.0",
-                "xdg-basedir": "^5.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/yeoman/update-notifier?sponsor=1"
-            }
-        },
-        "node_modules/update-notifier/node_modules/chalk": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-            "dev": true,
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/uri-js": {
@@ -13810,6 +13589,16 @@
                 "node": "^12.20.0 || >=14"
             }
         },
+        "node_modules/walk-up-path": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+            "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
         "node_modules/walker": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -13825,15 +13614,6 @@
             "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
             "dependencies": {
                 "defaults": "^1.0.3"
-            }
-        },
-        "node_modules/web-streams-polyfill": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 8"
             }
         },
         "node_modules/webidl-conversions": {
@@ -13935,87 +13715,37 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/widest-line": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
-            "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
-            "dev": true,
-            "dependencies": {
-                "string-width": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/widest-line/node_modules/ansi-regex": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/widest-line/node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-            "dev": true
-        },
-        "node_modules/widest-line/node_modules/string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-            "dev": true,
-            "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/widest-line/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
         "node_modules/wildcard-match": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/wildcard-match/-/wildcard-match-5.1.3.tgz",
-            "integrity": "sha512-a95hPUk+BNzSGLntNXYxsjz2Hooi5oL7xOfJR6CKwSsSALh7vUNuTlzsrZowtYy38JNduYFRVhFv19ocqNOZlg==",
-            "dev": true
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/wildcard-match/-/wildcard-match-5.1.4.tgz",
+            "integrity": "sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/windows-release": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-5.1.1.tgz",
-            "integrity": "sha512-NMD00arvqcq2nwqc5Q6KtrSRHK+fVD31erE5FEMahAw5PmVCgD7MUXodq3pdZSUkqA9Cda2iWx6s1XYwiJWRmw==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-7.1.1.tgz",
+            "integrity": "sha512-0GBwC9WmR8Bm3WYiz3FC391054BsFHZ2gzBVdYj9uj5eIVYzbn/YPYCYW9SWdh9vwnLuzpn1UGwJKiMG4F236w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "execa": "^5.1.1"
+                "powershell-utils": "^0.2.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/windows-release/node_modules/powershell-utils": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
+            "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -14034,7 +13764,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
             "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
@@ -14109,13 +13840,18 @@
                 }
             }
         },
-        "node_modules/xdg-basedir": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
-            "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+        "node_modules/wsl-utils": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+            "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0",
+                "powershell-utils": "^0.1.0"
+            },
             "engines": {
-                "node": ">=12"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -14165,15 +13901,19 @@
             "dev": true
         },
         "node_modules/yaml": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-            "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yargs": {
@@ -14215,11 +13955,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/yoctocolors-cjs": {
+        "node_modules/yoctocolors": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
-            "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+            "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },

--- a/packages/askui-nodejs/package.json
+++ b/packages/askui-nodejs/package.json
@@ -102,7 +102,7 @@
         "lint-staged": "15.5.2",
         "proxy": "^1.0.2",
         "proxy-agent": "^6.3.0",
-        "release-it": "20.0.0",
+        "release-it": "^20.0.1",
         "shx": "0.3.4",
         "ts-jest": "29.2.5",
         "typescript": "5.6.2"
@@ -115,6 +115,6 @@
     },
     "overrides": {
         "tmp": "0.2.5",
-        "basic-ftp": "5.3.0"
+        "basic-ftp": "5.3.1"
     }
 }

--- a/packages/askui-nodejs/package.json
+++ b/packages/askui-nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "askui",
-    "version": "0.31.0",
+    "version": "0.32.0",
     "license": "MIT",
     "author": "askui GmbH <info@askui.com> (http://www.askui.com/)",
     "description": "Reliable, automated end-to-end-testing that depends on what is shown on your screen instead of the technology you are running on",
@@ -44,7 +44,6 @@
         "release:prerelease": "cross-env HUSKY=0 release-it --preRelease=next",
         "release": "cross-env HUSKY=0 release-it",
         "generate:SBOM": "cyclonedx-npm package.json --omit dev --gather-license-texts --output-file bom.json --output-format JSON"
-
     },
     "files": [
         "dist/cjs/",
@@ -76,8 +75,8 @@
     },
     "devDependencies": {
         "@cyclonedx/cyclonedx-npm": "^4.1.2",
-        "@release-it/bumper": "6.0.1",
-        "@release-it/conventional-changelog": "8.0.2",
+        "@release-it/bumper": "7.0.5",
+        "@release-it/conventional-changelog": "11.0.0",
         "@types/fs-extra": "11.0.4",
         "@types/inquirer": "9.0.7",
         "@types/is-ci": "^3.0.4",
@@ -100,10 +99,10 @@
         "hpagent": "^1.2.0",
         "jest": "29.7.0",
         "jest-extended": "^4.0.2",
-        "lint-staged": "15.2.10",
+        "lint-staged": "15.5.2",
         "proxy": "^1.0.2",
         "proxy-agent": "^6.3.0",
-        "release-it": "17.6.0",
+        "release-it": "20.0.0",
         "shx": "0.3.4",
         "ts-jest": "29.2.5",
         "typescript": "5.6.2"
@@ -113,5 +112,9 @@
     },
     "optionalDependencies": {
         "sharp": "^0.33.5"
+    },
+    "overrides": {
+        "tmp": "0.2.5",
+        "basic-ftp": "5.3.0"
     }
 }


### PR DESCRIPTION
Upgrade release-it to 20.0.0, @release-it/bumper to 7.0.5, @release-it/conventional-changelog to 11.0.0, and lint-staged to 15.5.2. Add npm overrides pinning tmp to 0.2.5 and basic-ftp to 5.3.0 to remediate transitive advisories. lodash auto-bumps to 4.18.1 within the existing ^4.17.21 range.

npm audit now reports 0 vulnerabilities (previously 12: 3 low, 7 moderate, 2 high).