### PR TITLE
docs: document the release process incl. releasing from WSL on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,48 @@ To build the TypeScript ADK run
 npm run build
 ```
 
+## Releasing
+
+Releases of the TypeScript ADK are done manually with [release-it](https://github.com/release-it/release-it) from `packages/askui-nodejs` (configuration in `packages/askui-nodejs/.release-it.json`). The version increment is derived from the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) since the last release tag. Note that commits marked as breaking changes (`feat!`, `BREAKING CHANGE`) trigger a **major** bump — pass `--increment=minor` explicitly if that is not intended.
+
+### Requirements
+
+- A clean clone of this repository on the `main` branch (or a `*.*.x` maintenance branch)
+- Node.js 20 (the version used by CI)
+- npm account with publish access to the `askui` package, logged in via `npm login`. If your account enforces 2FA for writes, npm prompts for a one-time password during publish — so run the release interactively, or use a granular access token that bypasses 2FA.
+- `GITHUB_TOKEN` environment variable with `repo` scope (e.g. from `gh auth token`) so release-it can create the GitHub release; without it, release-it prints a pre-filled URL to create the release manually
+- Push access to `main` (the release commits the version bump and changelog and pushes it together with the release tag)
+
+### Running a release
+
+```sh
+cd packages/askui-nodejs
+npm ci
+npm run release              # or: npm run release:prerelease
+```
+
+### On Windows: release from WSL
+
+Do not release from Windows directly — use WSL (e.g. Ubuntu) instead. One-time setup:
+
+1. Install Node 20 inside WSL, e.g. via [nvm](https://github.com/nvm-sh/nvm)
+2. Clone the repository into the Linux file system (e.g. `~/askui`), **not** under `/mnt/c/...` — the Windows mount is slow and can cause line-ending issues
+3. Set your git identity inside WSL: `git config --global user.name "..."` and `git config --global user.email "..."`
+4. To reuse your Windows SSH keys/agent (e.g. 1Password) for pushing, let git in WSL delegate to the Windows SSH client:
+
+   ```sh
+   git config --global core.sshCommand /mnt/c/Windows/System32/OpenSSH/ssh.exe
+   ```
+
+5. Log in to npm inside WSL: `npm login`
+
+Then release as described above from the WSL clone.
+
+### Troubleshooting
+
+- **`npm error code E404` on publish**: npm masks missing publish permissions as 404. Check that `npm whoami` matches an account listed in `npm owner ls askui` and that no wrongly scoped token shadows your login in `~/.npmrc`.
+- **Publish succeeded but a later git step failed** (identity, push, ...): the npm version is already live, so do not run a full release again. Fix the cause, then complete only the git/GitHub half: `npm run release -- --ci --no-npm.publish` (add `--increment=minor` if it was used before).
+
 ## Contributing
 
 ### Branching


### PR DESCRIPTION
## Summary
Adds a Releasing section to the root README covering:

- How releases work (release-it from `packages/askui-nodejs`, version derived from conventional commits, `--increment=minor` to avoid unintended major bumps)
- Requirements: clean `main` clone, Node 20, npm publish access (2FA/OTP note), `GITHUB_TOKEN`, push access
- **Releasing from WSL on Windows**: nvm + Node 20, clone in the Linux filesystem, git identity, reusing the Windows SSH agent via `core.sshCommand`, `npm login` inside WSL
- Troubleshooting: the misleading `E404` on publish (missing permissions), and how to recover with `--no-npm.publish` when publish succeeded but git steps failed

Documents the process validated during the v0.33.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)